### PR TITLE
docs: add public architecture section

### DIFF
--- a/apps/docs/docs/Architecture/_category_.json
+++ b/apps/docs/docs/Architecture/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Architecture",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "Public architecture, infrastructure, security, and delivery notes for Alternun and AIRS."
+  }
+}

--- a/apps/docs/docs/Architecture/infrastructure-and-delivery.md
+++ b/apps/docs/docs/Architecture/infrastructure-and-delivery.md
@@ -1,0 +1,158 @@
+---
+sidebar_position: 4
+---
+
+# Infrastructure and Delivery
+
+Alternun provisions infrastructure from the monorepo through `packages/infra`.
+
+The project uses:
+
+- **SST** as the app wrapper and deployment entrypoint
+- **Pulumi AWS resources** inside the infra modules
+- **CodeBuild and CodePipeline** for managed delivery flows
+- **Route53 and ACM** for DNS and certificates
+
+## Stage Model
+
+The platform is split into several deployment families.
+
+### Public AIRS stages
+
+- `production`
+- `dev`
+- `mobile`
+
+Default public domains:
+
+- `airs.alternun.co`
+- `testnet.airs.alternun.co`
+- `preview.airs.alternun.co`
+
+### Backend and internal stages
+
+- `dashboard-dev`
+- `dashboard-prod`
+- `api-dev`
+- `api-prod`
+- `admin-dev`
+- `admin-prod`
+- `identity-dev`
+- `identity-prod`
+
+These let the team deploy internal surfaces independently or as a combined release unit.
+
+## Domain Model
+
+The current domain family separates public product surfaces from marketing surfaces.
+
+```mermaid
+flowchart TD
+  Root[alternun.co family]
+  Root --> AIRSProd[airs.alternun.co]
+  Root --> AIRSDev[testnet.airs.alternun.co]
+  Root --> AIRSPreview[preview.airs.alternun.co]
+  Root --> APIProd[api.alternun.co]
+  Root --> APIDev[testnet.api.alternun.co]
+  Root --> AdminProd[admin.alternun.co]
+  Root --> AdminDev[testnet.admin.alternun.co]
+  Root --> SSOProd[sso.alternun.co]
+  Root --> SSODev[testnet.sso.alternun.co]
+  Root --> Docs[docs.alternun.io]
+```
+
+Notable detail:
+
+- the public marketing/corporate site stays on `alternun.io`
+- application and identity surfaces use the `alternun.co` domain family
+
+## What The Infra Package Provisions
+
+### Public app delivery
+
+For AIRS, the infra package provisions:
+
+- static site delivery for the Expo web build
+- asset buckets
+- CloudFront-backed distribution path
+- stage-aware redirects
+
+### Backend API delivery
+
+For the custom API, the infra package provisions:
+
+- Lambda
+- API Gateway HTTP API
+- CloudWatch logging
+- custom domain mapping
+- ACM and DNS validation when needed
+
+### Admin delivery
+
+For the admin console, the infra package provisions:
+
+- static site hosting
+- CDN distribution
+- custom domains and certificates
+
+### Identity delivery
+
+For Authentik, the infra package provisions:
+
+- VPC and security groups
+- EC2 runtime host
+- optional RDS PostgreSQL
+- Secrets Manager payloads
+- Route53 records
+- ACME or ACM-backed TLS paths depending on stage
+
+## Pipeline Model
+
+The default pipeline catalog includes:
+
+- `production`
+- `dev`
+- `identity-dev`
+- `identity-prod`
+- `dashboard-dev`
+- `dashboard-prod`
+
+The default branch map in the infra config sends dev-oriented stacks to `develop` and production-oriented stacks to `master`.
+
+## Delivery Flow
+
+```mermaid
+flowchart LR
+  Dev[Developer change] --> Git[Git branch push]
+  Git --> Pipeline[CodePipeline and CodeBuild]
+  Pipeline --> Infra[packages/infra]
+  Infra --> Expo[AIRS static site deploy]
+  Infra --> Admin[Admin static site deploy]
+  Infra --> API[Lambda and API Gateway deploy]
+  Infra --> Identity[Authentik infra deploy]
+  Infra --> DNS[Route53 and ACM updates]
+```
+
+## Why There Are Combined And Dedicated Stacks
+
+The infra system supports both:
+
+- **combined dashboard stacks** for admin and API together
+- **dedicated escape-hatch stacks** for manual API-only or admin-only operations
+
+That design is pragmatic:
+
+- it keeps normal releases simpler
+- it still allows controlled component-specific deployment paths
+- it reduces accidental deletion risk by putting safety guards into the infra logic
+
+## Practical Source Of Truth
+
+If you want the live infra definitions, read these files in this order:
+
+1. `packages/infra/infra.config.ts`
+2. `packages/infra/config/infrastructure-specs.ts`
+3. `packages/infra/modules/*`
+4. `packages/infra/INFRASTRUCTURE_SPECS.md`
+
+The public docs here summarize those sources for human understanding, but the code remains the actual source of truth.

--- a/apps/docs/docs/Architecture/monorepo-and-stack.md
+++ b/apps/docs/docs/Architecture/monorepo-and-stack.md
@@ -1,0 +1,208 @@
+---
+sidebar_position: 2
+---
+
+# Monorepo and Stack
+
+Alternun uses a pnpm workspace monorepo with TurboRepo orchestration.
+
+That choice is intentional: the repo contains multiple apps that share infrastructure, auth patterns, translations, design primitives, and release automation.
+
+## Workspace Layout
+
+```mermaid
+flowchart TD
+  Root[alternun monorepo]
+  Root --> Apps[apps/*]
+  Root --> Packages[packages/*]
+  Root --> InternalDocs[docs/*]
+
+  Apps --> Mobile[apps/mobile]
+  Apps --> Admin[apps/admin]
+  Apps --> API[apps/api]
+  Apps --> DocsSite[apps/docs]
+  Apps --> Web[apps/web]
+
+  Packages --> Auth[@alternun/auth]
+  Packages --> UI[@alternun/ui]
+  Packages --> I18n[@alternun/i18n]
+  Packages --> Infra[@alternun/infra]
+  Packages --> Email[packages/email-templates]
+```
+
+## App Surfaces
+
+### `apps/mobile`
+
+Primary AIRS application codebase.
+
+Key technologies:
+
+- Expo
+- Expo Router
+- React 19
+- React Native 0.81
+- React Native Web
+- Supabase JavaScript client
+- WalletConnect
+- Firebase
+- NativeWind and Tailwind-oriented styling support
+
+Why it matters:
+
+- one codebase supports mobile-native patterns and web delivery
+- the public AIRS domain family is driven from this app through the infrastructure layer
+
+### `apps/admin`
+
+Internal admin console.
+
+Key technologies:
+
+- Vite
+- React 18
+- React Router
+- Refine
+- `oidc-client-ts`
+
+Why it matters:
+
+- it separates operational workflows from the public AIRS experience
+- it can be deployed together with the API in dashboard stacks
+
+### `apps/api`
+
+Custom backend service.
+
+Key technologies:
+
+- NestJS 10
+- Fastify 4
+- Swagger / OpenAPI
+- AWS Lambda adapter
+
+Why it matters:
+
+- gives the platform a place for custom backend logic that does not belong in the client
+- currently includes health endpoints and integration-oriented flows such as Decap OAuth bridge behavior
+
+### `apps/docs`
+
+Public documentation site.
+
+Key technologies:
+
+- Docusaurus 3
+- React
+- Mermaid diagrams
+- Decap CMS integration
+- `oidc-client-ts` for protected editor access
+
+Why it matters:
+
+- provides public product and developer documentation
+- supports a guarded editing workflow rather than editing content directly in production
+
+### `apps/web`
+
+Next.js application.
+
+Current role:
+
+- secondary web surface
+- not the primary public deployment target in the current infra model
+
+This is important for newcomers because the repo is **Expo-web-first** for the main AIRS deployment path, not Next.js-first.
+
+## Shared Packages
+
+### `@alternun/auth`
+
+Shared auth wrapper package.
+
+Purpose:
+
+- centralizes app-side auth abstractions
+- wraps the upstream auth library used by the project
+- adds mobile-oriented auth client behavior
+- includes SES and email support scripts around identity/email setup
+
+### `@alternun/ui`
+
+Shared UI component package.
+
+Purpose:
+
+- keeps reusable interface pieces out of a single app
+- supports multi-app reuse where design language overlaps
+
+### `@alternun/i18n`
+
+Shared translation catalog package.
+
+Purpose:
+
+- central place for locale data and runtime helpers
+- reused by apps instead of duplicating translation files everywhere
+
+### `packages/email-templates`
+
+Email generation and synchronization support.
+
+Purpose:
+
+- stores shared localized email content
+- supports downstream delivery systems such as Supabase email/template sync
+
+### `@alternun/infra`
+
+The deployment and platform package.
+
+Purpose:
+
+- defines AWS resources
+- controls domain and stage mapping
+- owns pipeline creation and deployment safety checks
+- acts as the operational backbone of the monorepo
+
+## Core Tooling
+
+The repo is coordinated with a small set of high-leverage tools:
+
+- **pnpm** for workspace package management
+- **TurboRepo** for build graph orchestration
+- **TypeScript** across the monorepo
+- **ESLint** and **Prettier** for code hygiene
+- **Husky** and **lint-staged** for pre-commit enforcement
+
+## Build and Task Model
+
+At the repo root, common commands are standardized:
+
+- `pnpm build`
+- `pnpm dev`
+- `pnpm lint`
+- `pnpm type-check`
+- `pnpm test`
+
+Turbo coordinates these tasks so package dependencies build in the right order.
+
+That gives the team a practical middle ground:
+
+- apps can evolve independently
+- shared packages stay reusable
+- cross-cutting changes can still be verified from one root command set
+
+## Why This Structure Works
+
+This monorepo is optimized for platform work rather than a single standalone app.
+
+That means the structure is less about "frontend versus backend" and more about:
+
+- public experience
+- internal operations
+- identity and trust boundaries
+- deployable infrastructure
+- shared product building blocks
+
+For public contributors, that is the most important mental model to keep in mind while exploring the codebase.

--- a/apps/docs/docs/Architecture/next-improvements.md
+++ b/apps/docs/docs/Architecture/next-improvements.md
@@ -1,0 +1,109 @@
+---
+sidebar_position: 6
+---
+
+# Next Improvements
+
+This page documents the most important next steps for the platform from an engineering point of view.
+
+It is intentionally practical. The goal is not to describe a perfect future-state diagram, but to identify the next improvements that would materially strengthen the platform.
+
+## 1. Expand The Custom API Carefully
+
+The NestJS API should continue to grow, but not by becoming a rushed dumping ground for logic.
+
+High-value next steps:
+
+- add more domain endpoints with documented DTOs and auth guards
+- expand OpenAPI coverage so the backend contract is public and reviewable
+- add stronger integration tests for auth, health, and operational flows
+- tighten CORS to explicit allowed origins per environment
+
+## 2. Mature The AIRS Runtime Contract
+
+The public AIRS app already carries meaningful product responsibility. The next step is to make its backend and identity contract more explicit.
+
+Suggested improvements:
+
+- document stable client-to-service contracts
+- clarify which concerns belong in Supabase versus the custom API
+- standardize role and claim handling across app surfaces
+- document wallet-related trust and fallback behavior more clearly
+
+## 3. Improve Infrastructure Observability
+
+The infra package already deploys the platform, but visibility into runtime health can improve.
+
+Suggested improvements:
+
+- stage dashboards for API, identity, and static delivery
+- deployment summaries with direct links to health and docs endpoints
+- structured application logs and trace correlation
+- explicit alerting for key identity and API failures
+
+## 4. Harden Security Automation
+
+Useful next controls would include:
+
+- stricter dependency review workflow
+- automated SBOM generation for release artifacts
+- scheduled vulnerability reporting beyond basic audit commands
+- stronger secret handling verification in CI
+- a public security.md process for coordinated reporting
+
+## 5. Reduce Deployment Complexity
+
+The current stack model is powerful, but some stage alias behavior and ownership boundaries are still easy to misunderstand.
+
+Good next steps:
+
+- simplify stage naming rules where possible
+- make combined versus dedicated stack ownership easier to reason about
+- document all deploy-safe paths in one canonical page
+- add more automated checks for stack alias collisions and route overlap
+
+## 6. Improve Open-Source Onboarding
+
+For public contributors, the repo still needs a smoother first-hour experience.
+
+Suggested improvements:
+
+- add a contributor-first architecture quickstart
+- publish a "how to run the main surfaces locally" page
+- document expected environment variables per app
+- maintain an index of architecture decision records
+
+## 7. Keep The Docs As A First-Class Surface
+
+The docs should remain synchronized with the codebase rather than becoming a stale explanation layer.
+
+Recommended habits:
+
+- update docs when deployment model changes
+- update docs when auth boundaries change
+- document new public APIs as part of implementation, not later
+- keep Mermaid diagrams close to the current runtime, not future guesses
+
+## Improvement Map
+
+```mermaid
+flowchart TD
+  Now[Current platform foundation]
+  Now --> API[Broader API contracts]
+  Now --> Observability[Better observability]
+  Now --> Security[Stronger security automation]
+  Now --> Onboarding[Better contributor onboarding]
+  Now --> Simplification[Simpler deployment model]
+  Now --> Docs[Living architecture docs]
+```
+
+## Final Note
+
+The most useful improvements are the ones that reduce ambiguity.
+
+In this repo, that usually means:
+
+- make boundaries clearer
+- make deployments safer
+- make contracts more explicit
+- make documentation easier to trust

--- a/apps/docs/docs/Architecture/overview.md
+++ b/apps/docs/docs/Architecture/overview.md
@@ -1,0 +1,132 @@
+---
+sidebar_position: 1
+---
+
+# Alternun and AIRS Architecture
+
+This section is the public technical map of the Alternun platform.
+
+It is written for:
+
+- users who want to understand how the product is assembled
+- new engineers joining the project
+- external contributors reading the monorepo for the first time
+- open-source community members who want a clear system description before going into the code
+
+## What is Alternun?
+
+Alternun is the broader product and infrastructure umbrella.
+
+Today the repo contains several connected surfaces:
+
+- **AIRS**: the public application experience delivered from the Expo-based client stack
+- **Admin**: the internal operational console for managed workflows
+- **API**: the custom backend service used for operational and integration endpoints
+- **Identity**: the Authentik-based authentication and OIDC layer
+- **Docs**: the public Docusaurus documentation site and protected CMS editor
+- **Infra**: the SST and Pulumi code that provisions AWS resources and deployment pipelines
+
+## What is AIRS?
+
+AIRS is the current user-facing application surface under the `airs.alternun.co` domain family.
+
+In practical terms, AIRS is the part of the system that end users interact with first:
+
+- onboarding and marketing-like experience inside the Expo web app
+- authentication and session handling
+- user dashboard concepts such as AIRS balance, portfolio, and impact-related activity
+- mobile and web delivery from one shared application codebase
+
+## System At A Glance
+
+```mermaid
+flowchart LR
+  Users[Users] --> AIRS[AIRS app<br/>apps/mobile]
+  Admins[Operators and admins] --> Admin[Admin console<br/>apps/admin]
+  Editors[Docs editors] --> Docs[Docs site and CMS<br/>apps/docs]
+
+  AIRS --> Auth[Authentik identity<br/>sso.alternun.co family]
+  Admin --> Auth
+  Docs --> Auth
+
+  AIRS --> Supabase[Supabase<br/>data and app authorization]
+  Admin --> API[NestJS API<br/>apps/api]
+  Docs --> API
+  API --> Supabase
+  API --> GitHub[GitHub and Decap OAuth]
+
+  Auth --> AWS[AWS infrastructure]
+  API --> AWS
+  Admin --> AWS
+  AIRS --> AWS
+```
+
+## Architectural Principles
+
+The monorepo currently follows a few practical principles:
+
+1. **One repository, multiple delivery surfaces.** Public app, admin, docs, API, and infrastructure live together so shared changes can be coordinated.
+2. **Shared building blocks before duplicated logic.** Authentication, i18n, UI, and email templates are split into reusable packages.
+3. **Environment-aware delivery.** The project ships different stacks for production, dev/testnet, preview/mobile, dashboard, and identity.
+4. **Infrastructure as code first.** AWS resources, domains, pipelines, redirects, and runtime defaults are defined in `packages/infra`.
+5. **Hybrid backend model.** The platform currently combines managed services such as Supabase with a growing custom NestJS backend.
+
+## The Three Main Planes
+
+### 1. Product Plane
+
+This is what end users and community members experience:
+
+- AIRS public app
+- account and wallet entry points
+- user dashboard and impact-related interfaces
+- multilingual content and email touchpoints
+
+### 2. Operations Plane
+
+This is where internal teams work:
+
+- admin console
+- docs editing workflow
+- backend operational endpoints
+- pipeline-driven deployments
+
+### 3. Platform Plane
+
+This is the foundation layer:
+
+- identity
+- DNS
+- certificates
+- static hosting
+- Lambda and API Gateway
+- EC2 and RDS for Authentik
+- CodeBuild and CodePipeline driven delivery
+
+## Current State
+
+The repo is already structured like a platform, but not every subsystem is equally mature.
+
+What is already clear and active:
+
+- public AIRS app delivery
+- AWS-managed deployment topology
+- Authentik-based identity direction
+- Docusaurus docs and Decap editing flow
+- admin and API deployment stacks
+
+What is still growing:
+
+- broader custom API surface
+- deeper observability
+- stronger automated security and regression coverage
+- more public developer-facing architecture notes
+
+## Read This Section In Order
+
+For the clearest onboarding path:
+
+1. Start with [Monorepo and Stack](./monorepo-and-stack.md)
+2. Continue to [Runtime Architecture](./runtime-architecture.md)
+3. Then read [Infrastructure and Delivery](./infrastructure-and-delivery.md)
+4. Finish with [Security and Quality](./security-and-quality.md) and [Next Improvements](./next-improvements.md)

--- a/apps/docs/docs/Architecture/runtime-architecture.md
+++ b/apps/docs/docs/Architecture/runtime-architecture.md
@@ -1,0 +1,162 @@
+---
+sidebar_position: 3
+---
+
+# Runtime Architecture
+
+The running system is a combination of client applications, managed services, and AWS-hosted custom services.
+
+The simplest way to understand it is to follow the trust boundaries.
+
+## Runtime Topology
+
+```mermaid
+flowchart LR
+  subgraph Client["Client surfaces"]
+    AIRS[AIRS app<br/>Expo / React Native / Web]
+    Admin[Admin console<br/>Vite / React / Refine]
+    Docs[Docs site<br/>Docusaurus]
+  end
+
+  subgraph Identity["Identity boundary"]
+    Authentik[Authentik OIDC provider]
+  end
+
+  subgraph Data["Application data and business state"]
+    Supabase[Supabase]
+  end
+
+  subgraph Custom["Custom backend and integrations"]
+    API[NestJS + Fastify API]
+    GitHub[GitHub and Decap]
+  end
+
+  AIRS --> Authentik
+  AIRS --> Supabase
+
+  Admin --> Authentik
+  Admin --> API
+
+  Docs --> Authentik
+  Docs --> API
+  API --> GitHub
+
+  API --> Supabase
+```
+
+## Trust Model
+
+The repo's current identity direction is:
+
+- Authentik is the identity provider and OIDC source of truth
+- Supabase remains an application data and authorization layer
+- custom backend capabilities live in the NestJS API
+
+This creates a hybrid runtime model:
+
+- identity is not owned by the frontend
+- core product data is not hard-coded into the API
+- some workflows remain service-driven while the custom API grows over time
+
+## AIRS Runtime
+
+For AIRS, the current runtime is centered on the Expo app:
+
+- the same app family supports mobile-native behavior and web publishing
+- authentication is abstracted through the shared auth package
+- Supabase is already part of the client-side integration model
+- wallet-related behavior is present in the public app stack
+
+In other words, AIRS is not just a static marketing frontend. It is the beginning of the actual application runtime.
+
+## Admin Runtime
+
+The admin console is intentionally separate from the public AIRS app:
+
+- it has its own deployment target
+- it uses OIDC flows through Authentik
+- it is designed for internal and operational use
+- it can be shipped together with the custom API in combined dashboard stacks
+
+That separation reduces accidental coupling between public user journeys and internal operator workflows.
+
+## Documentation Runtime
+
+The docs system has two modes:
+
+1. public documentation delivery through Docusaurus
+2. protected editorial workflow through Decap CMS plus Authentik gating
+
+That means the docs are treated as a real product surface with authentication, content workflow, and infrastructure dependencies, not just a static folder of markdown files.
+
+## Example Flow: AIRS Sign-In
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant AIRS as AIRS app
+  participant Auth as Authentik
+  participant Data as Supabase
+
+  User->>AIRS: Open app and request sign-in
+  AIRS->>Auth: Start OIDC or auth flow
+  Auth-->>AIRS: Return session and claims
+  AIRS->>Data: Use session-backed application access
+  Data-->>AIRS: Return user-facing state
+  AIRS-->>User: Render dashboard and app features
+```
+
+## Example Flow: Docs Editing
+
+```mermaid
+sequenceDiagram
+  participant Editor
+  participant Docs as Docusaurus admin page
+  participant Auth as Authentik
+  participant API as NestJS API
+  participant GitHub
+
+  Editor->>Docs: Open /admin
+  Docs->>Auth: Verify editor session
+  Auth-->>Docs: Return approved session
+  Docs->>API: Start Decap OAuth bridge
+  API->>GitHub: Exchange OAuth authorization
+  GitHub-->>API: Return token
+  API-->>Docs: Return popup result to Decap
+  Docs-->>Editor: Open CMS editor
+```
+
+## What Lives Where Today
+
+### Mostly client-driven today
+
+- AIRS UI rendering
+- app-side session handling
+- multilingual presentation
+- user journey and interface composition
+
+### Mostly service-driven today
+
+- identity
+- infrastructure provisioning
+- deployment pipelines
+- documentation publishing
+
+### Growing custom backend area
+
+- NestJS operational API
+- OpenAPI documentation
+- integration glue such as OAuth bridge endpoints
+- future backend domain logic that should not stay in clients
+
+## Important Architectural Reality
+
+This repo is not yet a "single backend owns everything" architecture.
+
+It is a platform in transition:
+
+- some capabilities are already centralized
+- some are intentionally delegated to managed services
+- some are still moving from client-side patterns into dedicated backend services
+
+That is not a problem by itself, but it is important for contributors to understand before proposing large refactors.

--- a/apps/docs/docs/Architecture/security-and-quality.md
+++ b/apps/docs/docs/Architecture/security-and-quality.md
@@ -1,0 +1,156 @@
+---
+sidebar_position: 5
+---
+
+# Security and Quality
+
+Security in this repo is a combination of runtime controls, infrastructure guardrails, and development workflow discipline.
+
+The important point for contributors is this:
+
+**quality is not one tool**. It is a chain of controls across application code, identity, deployment, and review.
+
+## Security Model Today
+
+### Identity boundary
+
+The current architecture direction is:
+
+- Authentik is the identity provider
+- Supabase remains a data and authorization layer
+- app and admin clients do not become their own identity source of truth
+
+This is a good separation because it keeps authentication ownership explicit.
+
+### API input handling
+
+The NestJS API already enables important validation defaults:
+
+- `ValidationPipe`
+- `whitelist: true`
+- `transform: true`
+- `forbidNonWhitelisted: true`
+
+Those defaults reduce common input-shape mistakes and accidental over-posting.
+
+### Secrets and environment handling
+
+The repo also has infra-first environment handling:
+
+- environment-first deploy scripts
+- Secrets Manager integration in the identity stack
+- stage-aware configuration
+- deployment guards around stack types and pipeline reconciliation
+
+## Quality Controls In The Repo
+
+### Static quality controls
+
+- TypeScript across apps and packages
+- ESLint
+- Prettier
+- `lint-staged`
+- Husky pre-commit and pre-push hooks
+- `eslint-plugin-security`
+
+### Validation and release controls
+
+- version validation scripts
+- secret scanning hooks
+- Turbo-based `build`, `lint`, `type-check`, and `test` orchestration
+- branch and pipeline safety scripts in `packages/infra/scripts`
+
+### Documentation and API quality
+
+- Docusaurus docs are built from the same monorepo
+- the API exposes Swagger / OpenAPI docs
+- operational docs already exist in-repo for identity and infra decisions
+
+## Contributor Checklist
+
+When changing code in this repo, contributors should actively check:
+
+1. **Input validation**: does the endpoint or function strictly validate shape and type?
+2. **Secret handling**: is any secret leaking into client-side code, logs, or committed files?
+3. **Auth boundary**: is the change respecting the existing identity model instead of bypassing it?
+4. **Stage awareness**: does the change behave correctly in dev, production, and preview/testnet contexts?
+5. **Infra safety**: could the change cause destructive deployment side effects?
+6. **Docs impact**: does the public or operator-facing behavior need documentation updates?
+
+## Current Strengths
+
+These are already positive signals in the repository:
+
+- clear separation between public app, admin, docs, API, and infra
+- identity treated as a dedicated subsystem
+- infrastructure managed as code
+- release automation present in the monorepo
+- shared packages used instead of uncontrolled duplication
+- public docs site already part of the platform
+
+## Known Gaps And Risks
+
+The current architecture is solid enough to grow, but several gaps are still visible.
+
+### 1. API security posture needs tightening
+
+Examples:
+
+- CORS is currently permissive in the Nest bootstrap
+- the custom API surface is still early and needs broader policy hardening
+- more endpoint-level auth and authorization coverage will be needed as the API grows
+
+### 2. Test coverage is uneven
+
+Some parts of the repo have testing patterns, but coverage is not yet equally mature across every app and service.
+
+### 3. Observability is still light
+
+The AWS runtime includes logs, but the platform still needs a richer operational story around:
+
+- structured tracing
+- service-level dashboards
+- alerting
+- deployment-level health visibility
+
+### 4. Security automation can go further
+
+Good foundations exist, but the repo would benefit from more formalized:
+
+- dependency review
+- SBOM generation
+- artifact provenance
+- container and image scanning where relevant
+- threat modeling for new services
+
+### 5. Public architectural explanation is still catching up
+
+This new section improves that situation, but architecture notes still need to keep pace with implementation.
+
+## Linting And Security Workflow
+
+For day-to-day engineering, a practical baseline is:
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+pnpm --filter @alternun/api run build
+pnpm --filter alternun-docs run build
+```
+
+If a change touches infrastructure or identity, contributors should also inspect the relevant `packages/infra` scripts and settings before assuming a deploy is safe.
+
+## Public Security Posture Statement
+
+Alternun is building in public, but it should not confuse transparency with loose controls.
+
+The target posture is:
+
+- public architecture visibility
+- private secret handling
+- explicit trust boundaries
+- reproducible deployments
+- conservative operational defaults
+
+That is the standard contributors should aim to maintain.

--- a/apps/docs/docs/intro.md
+++ b/apps/docs/docs/intro.md
@@ -51,6 +51,15 @@ Join us as we build a future where nature and wealth grow together.
 
 Ready to go deep in the Digital Gold Mining, check out how we create the Gold Backed Tokens [Gold-Backed Tokens](/docs/tutorial-basics/gold-backed-tokens)
 
+## For Builders And Contributors
+
+If you are exploring the repository, onboarding to the engineering team, or reviewing the platform as an open-source contributor, start with the new architecture section:
+
+- [Alternun and AIRS Architecture](/docs/Architecture/overview)
+- [Monorepo and Stack](/docs/Architecture/monorepo-and-stack)
+- [Infrastructure and Delivery](/docs/Architecture/infrastructure-and-delivery)
+- [Security and Quality](/docs/Architecture/security-and-quality)
+
 :::info
 Regenerative Finance + Decentralized Finance = ReDeFi
 :::


### PR DESCRIPTION
## Summary
- add a new public Architecture section to the Docusaurus docs
- document the Alternun and AIRS system overview, monorepo layout, runtime boundaries, infrastructure, security posture, and next improvements
- link the new architecture section from the docs introduction

## Validation
- pnpm --filter alternun-docs run build