### PR TITLE
docs: improve mermaid dark mode contrast

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -150,7 +150,7 @@ const config: Config = {
     image: 'img/alternun-socials.png',
     favicon: 'img/favicon.ico',
     mermaid: {
-      theme: { light: 'neutral', dark: 'forest' },
+      theme: { light: 'neutral', dark: 'dark' },
     },
     navbar: {
       title: '',

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -37,3 +37,47 @@
 [data-theme='dark'] .navbar__logo img {
   content: url('/img/alternun-white.svg');
 }
+
+/* Improve Mermaid readability against the docs dark surface. */
+[data-theme='dark'] .docusaurus-mermaid-container svg .messageText,
+[data-theme='dark'] .docusaurus-mermaid-container svg .labelText,
+[data-theme='dark'] .docusaurus-mermaid-container svg .labelText > tspan,
+[data-theme='dark'] .docusaurus-mermaid-container svg .loopText,
+[data-theme='dark'] .docusaurus-mermaid-container svg .loopText > tspan,
+[data-theme='dark'] .docusaurus-mermaid-container svg .noteText,
+[data-theme='dark'] .docusaurus-mermaid-container svg .noteText > tspan,
+[data-theme='dark'] .docusaurus-mermaid-container svg .edgeLabel text,
+[data-theme='dark'] .docusaurus-mermaid-container svg .cluster-label text,
+[data-theme='dark'] .docusaurus-mermaid-container svg .cluster text,
+[data-theme='dark'] .docusaurus-mermaid-container svg .legend text,
+[data-theme='dark'] .docusaurus-mermaid-container svg .sectionTitle {
+  fill: #f3f7fb !important;
+  color: #f3f7fb !important;
+}
+
+[data-theme='dark'] .docusaurus-mermaid-container svg .actor-line,
+[data-theme='dark'] .docusaurus-mermaid-container svg .messageLine0,
+[data-theme='dark'] .docusaurus-mermaid-container svg .messageLine1,
+[data-theme='dark'] .docusaurus-mermaid-container svg .loopLine,
+[data-theme='dark'] .docusaurus-mermaid-container svg .edgePath .path,
+[data-theme='dark'] .docusaurus-mermaid-container svg .flowchart-link,
+[data-theme='dark'] .docusaurus-mermaid-container svg .relationshipLine,
+[data-theme='dark'] .docusaurus-mermaid-container svg .relation {
+  stroke: #b7c7d8 !important;
+}
+
+[data-theme='dark'] .docusaurus-mermaid-container svg .arrowheadPath,
+[data-theme='dark'] .docusaurus-mermaid-container svg #arrowhead path,
+[data-theme='dark'] .docusaurus-mermaid-container svg #crosshead path {
+  fill: #b7c7d8 !important;
+  stroke: #b7c7d8 !important;
+}
+
+[data-theme='dark'] .docusaurus-mermaid-container svg .note,
+[data-theme='dark'] .docusaurus-mermaid-container svg .labelBox,
+[data-theme='dark'] .docusaurus-mermaid-container svg .edgeLabel rect,
+[data-theme='dark'] .docusaurus-mermaid-container svg .labelBkg {
+  fill: #253345 !important;
+  stroke: #8fa5ba !important;
+  background-color: #253345 !important;
+}


### PR DESCRIPTION
## Summary
- switch Mermaid dark mode to the built-in dark theme for better defaults
- add dark-mode Mermaid overrides so legend, note, and edge labels stay readable
- improve line and arrow contrast against the docs dark background

## Verification
- pnpm --filter alternun-docs run build (main workspace: passed for en/es/th before remote sync)
- pnpm --filter alternun-docs run build (clean worktree: en/es passed, th currently fails on existing Docusaurus SSG issues unrelated to this patch)
- npx -y react-doctor@latest . --verbose --diff (98/100, pre-existing warnings only)