### PR TITLE
fix infra deploy pipeline for expo and backend rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.0.195](https://github.com/alternun-development/alternun/compare/v1.0.194-dev.0...v1.0.195) (2026-04-22)
+
+### Bug Fixes
+
+- **repo:** fix(infra): build expo site before sync
+- **repo:** updates
+- **repo:** fix(infra): rebuild backend api before deploy
+
+### Bug Fixes
+
+- **infra:** build expo site before sync ([0a0d694](https://github.com/alternun-development/alternun/commit/0a0d6941bd776988f0c311429a98c3e0449df767))
+- **infra:** rebuild backend api before deploy ([5733668](https://github.com/alternun-development/alternun/commit/5733668ccee45d907b89161ac7a8f3614e043423))
+
 ## [1.0.194](https://github.com/alternun-development/alternun/compare/v1.0.193-dev.0...v1.0.194) (2026-04-21)
 
 ### Bug Fixes

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/admin",
-  "version": "1.0.194",
+  "version": "1.0.195",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/api",
-  "version": "1.0.194",
+  "version": "1.0.195",
   "private": true,
   "scripts": {
     "dev": "nodemon --watch src --ext ts --signal SIGTERM --exec \"node -r ts-node/register/transpile-only src/main.ts\"",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun-docs",
-  "version": "1.0.194",
+  "version": "1.0.195",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "test-tempo",
     "slug": "test-tempo",
-    "version": "1.0.194-dev.0",
+    "version": "1.0.195-dev.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alternun/mobile",
   "main": "expo-router/entry",
-  "version": "1.0.194",
+  "version": "1.0.195",
   "scripts": {
     "start": "pnpm --filter alternun changelog:sync && expo start",
     "build": "./build.sh",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/web",
-  "version": "1.0.194",
+  "version": "1.0.195",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun",
-  "version": "1.0.194",
+  "version": "1.0.195",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/auth",
-  "version": "1.0.194",
+  "version": "1.0.195",
   "description": "Alternun auth wrapper package built on top of @edcalderon/auth",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/i18n",
-  "version": "1.0.194",
+  "version": "1.0.195",
   "description": "Shared translation catalogs and locale helpers for Alternun apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/infra/buildspec.yml
+++ b/packages/infra/buildspec.yml
@@ -411,6 +411,13 @@ phases:
           echo "Skipping backend API build (INFRA_ENABLE_BACKEND_API=${INFRA_ENABLE_BACKEND_API:-false})"
         fi
 
+        if [ "${INFRA_ENABLE_EXPO_SITE:-true}" = "true" ]; then
+          echo "Building Expo web app with: pnpm --filter @alternun/mobile run build:web"
+          pnpm --filter @alternun/mobile run build:web
+        else
+          echo "Skipping Expo web build (INFRA_ENABLE_EXPO_SITE=${INFRA_ENABLE_EXPO_SITE:-true})"
+        fi
+
         if [ "${INFRA_ENABLE_SST_REFRESH}" = "true" ]; then
           (cd "${INFRA_PATH}" && npx sst refresh --stage ${SST_STAGE})
         else

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/infra",
-  "version": "1.0.194",
+  "version": "1.0.195",
   "private": true,
   "type": "module",
   "description": "Alternun AWS/SST infrastructure wrapper for Expo web deployments.",

--- a/packages/infra/test/static-site-invalidation.test.ts
+++ b/packages/infra/test/static-site-invalidation.test.ts
@@ -28,6 +28,10 @@ void test('static site invalidation waits are configurable and default to non-bl
   assert.doesNotMatch(adminSiteSource, /wait:\s*deploymentStage\s*===\s*'production'/);
 
   assert.match(buildspecSource, /touch \.sst-deploy-succeeded/);
+  assert.match(
+    buildspecSource,
+    /Building Expo web app with: pnpm --filter @alternun\/mobile run build:web/
+  );
   assert.match(buildspecSource, /sync-expo-site-assets\.sh/);
   assert.match(
     buildspecSource,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/ui",
-  "version": "1.0.194",
+  "version": "1.0.195",
   "description": "Common UI components for Alternun",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/update/package.json
+++ b/packages/update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/update",
-  "version": "1.0.194",
+  "version": "1.0.195",
   "description": "Shared release update detection and service worker helpers for Alternun web apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/version.development.json
+++ b/version.development.json
@@ -1,22 +1,22 @@
 {
-  "version": "1.0.194-dev.0",
+  "version": "1.0.195-dev.0",
   "build": 0,
-  "lastUpdated": "2026-04-21T23:04:10.078Z",
+  "lastUpdated": "2026-04-22T00:54:06.074Z",
   "environment": "development",
   "lastDeployment": {
     "id": "development-0",
-    "version": "1.0.194-dev.0",
+    "version": "1.0.195-dev.0",
     "build": 0,
-    "date": "2026-04-21T23:04:10.078Z",
-    "message": "Release 1.0.194-dev.0"
+    "date": "2026-04-22T00:54:06.074Z",
+    "message": "Release 1.0.195-dev.0"
   },
   "deploymentHistory": [
     {
       "id": "development-0",
-      "version": "1.0.194-dev.0",
+      "version": "1.0.195-dev.0",
       "build": 0,
-      "date": "2026-04-21T23:04:10.078Z",
-      "message": "Release 1.0.194-dev.0"
+      "date": "2026-04-22T00:54:06.074Z",
+      "message": "Release 1.0.195-dev.0"
     },
     {
       "id": "development-1",


### PR DESCRIPTION
## Summary\n- rebuild backend API artifacts before SST deploy for backend-enabled stages\n- build Expo web artifacts before static site sync in CodeBuild\n\n## Validation\n- pnpm --filter @alternun/infra type-check\n- pnpm --filter @alternun/infra exec node --test --experimental-strip-types test/static-site-invalidation.test.ts\n\n## Notes\n- The repo uses develop -> master, so this PR targets master rather than main.