### PR TITLE
chore: release v1.0.195

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -23,7 +23,7 @@ jobs:
           case "$mode" in
             on|ON|true|TRUE|1|yes|YES)
               echo "✅ Testnet mode enabled: direct pushes to master/main are allowed."
-              echo "🔄 master/main will be mirrored into develop by workflow."
+              echo "ℹ️ master/main no longer auto-mirrors into develop; use the sync workflow manually when needed."
               exit 0
               ;;
           esac

--- a/.github/workflows/sync-master-to-develop.yml
+++ b/.github/workflows/sync-master-to-develop.yml
@@ -1,8 +1,12 @@
 name: Sync Master To Develop
 
 on:
-  push:
-    branches: [master, main]
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: Branch to mirror into develop
+        required: true
+        default: master
 
 permissions:
   contents: write
@@ -51,7 +55,7 @@ jobs:
       - name: Fast-forward develop from master/main
         if: steps.mode.outputs.enabled == 'true'
         env:
-          SOURCE_BRANCH: ${{ github.ref_name }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
         run: |
           git fetch origin develop "$SOURCE_BRANCH"
           git checkout -B develop-sync "origin/develop"

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "test-tempo",
     "slug": "test-tempo",
-    "version": "1.0.195-dev.0",
+    "version": "1.0.195",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",

--- a/docs/expo-web-aws-deploy.md
+++ b/docs/expo-web-aws-deploy.md
@@ -20,9 +20,9 @@ Set AWS credentials and region for the IAM user with deploy permissions.
 
 Current testnet mode:
 
-- `master` is the working branch
-- `develop` is the mirrored branch for the dev/testnet pipeline
-- every push to `master`/`main` is mirrored into `develop` by GitHub Actions
+- `master` owns production releases
+- `develop` owns dev/testnet releases
+- the branches are independent unless you explicitly run the sync helper
 
 Manual sync remains available when needed.
 

--- a/packages/infra/README.md
+++ b/packages/infra/README.md
@@ -510,13 +510,16 @@ Run only from a clean working tree:
 pnpm --filter @alternun/infra run sync:master-develop
 ```
 
-Current testnet mode uses `master -> develop` as the fast-forward direction.
+Current testnet mode keeps `master` and `develop` independent by default.
 
-This script does a fast-forward-only sync:
+The helper does a fast-forward-only sync when you explicitly run it:
 
 1. fetches `master` and `develop`
 2. fast-forwards `develop` from `master`
 3. pushes `develop`
+
+The GitHub Actions workflow that used to mirror `master` into `develop` is now manual-only.
+Use it only when you deliberately want to resync testnet from production.
 
 The legacy promotion helper still exists:
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -659,17 +659,7 @@ function promoteRelease({ version, remote, dryRun, productionBranch }) {
     }
 
     run('git', ['push', remote, productionBranch, '--follow-tags'], { dryRun });
-    run('bash', ['packages/infra/scripts/sync-master-develop.sh'], {
-      dryRun,
-      env: {
-        ...process.env,
-        REMOTE: remote,
-        SOURCE_BRANCH: productionBranch,
-        TARGET_BRANCH: 'develop',
-        RETURN_BRANCH: productionBranch,
-      },
-    });
-    console.log(`Promoted v${version}: pushed ${productionBranch} and fast-forwarded develop.`);
+    console.log(`Promoted v${version}: pushed ${productionBranch}.`);
     return;
   }
 

--- a/version.production.json
+++ b/version.production.json
@@ -1,22 +1,22 @@
 {
-  "version": "1.0.191",
-  "build": 3,
-  "lastUpdated": "2026-04-21T19:11:26.800Z",
+  "version": "1.0.195",
+  "build": 4,
+  "lastUpdated": "2026-04-22T01:43:47.528Z",
   "environment": "production",
   "lastDeployment": {
-    "id": "production-3",
-    "version": "1.0.191",
-    "build": 3,
-    "date": "2026-04-21T19:11:26.800Z",
-    "message": "Release 1.0.191-dev.3"
+    "id": "production-4",
+    "version": "1.0.195",
+    "build": 4,
+    "date": "2026-04-22T01:43:47.528Z",
+    "message": "Release 1.0.195"
   },
   "deploymentHistory": [
     {
-      "id": "production-3",
-      "version": "1.0.191",
-      "build": 3,
-      "date": "2026-04-21T19:11:26.800Z",
-      "message": "Release 1.0.191-dev.3"
+      "id": "production-4",
+      "version": "1.0.195",
+      "build": 4,
+      "date": "2026-04-22T01:43:47.528Z",
+      "message": "Release 1.0.195"
     },
     {
       "id": "production-1",


### PR DESCRIPTION
Production release for v1.0.195.

Includes:
- independent dev/prod pipeline triggering
- production version manifest aligned to 1.0.195
- release promote flow no longer auto-syncs develop