### PR TITLE
chore: sync develop → master (v1.0.287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.0.288](https://github.com/alternun-development/alternun/compare/v1.0.286...v1.0.288) (2026-06-27)
+
+### Bug Fixes
+
+- **repo:** chore(repo,admin,api): CHANGELOG, README, app, version.development
+- **repo:** fix(infra): sst-deploy
+
+### Bug Fixes
+
+- **infra:** sst-deploy ([721170d](https://github.com/alternun-development/alternun/commit/721170d578c2411d4242a778e76a1380fd6ad7d6))
+
 ## [1.0.287](https://github.com/alternun-development/alternun/compare/v1.0.286...v1.0.287) (2026-06-27)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
+## [1.0.287](https://github.com/alternun-development/alternun/compare/v1.0.286...v1.0.287) (2026-06-27)
+
+### Bug Fixes
+
+- **repo:** fix(infra): sst-deploy
+
+### Bug Fixes
+
+- **infra:** sst-deploy ([721170d](https://github.com/alternun-development/alternun/commit/721170d578c2411d4242a778e76a1380fd6ad7d6))
+
 ## [1.0.286](https://github.com/alternun-development/alternun/compare/v1.0.286-dev.0...v1.0.286) (2026-06-27)
 
 ### Bug Fixes
 
 - **repo:** docs: sync root README for v1.0.286
-
-
-
-
-
 
 ## [1.0.286](https://github.com/alternun-development/alternun/compare/v1.0.285...v1.0.286) (2026-06-27)
 

--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ pnpm version:check-secrets # scan staged files for secrets
 The root README is kept aligned with the current release state by the local README maintenance hook. `pnpm version:validate` now includes the README guard, and the release flow refreshes the version line, latest changes block, and support contact automatically.
 The CI test job now generates `apps/mobile/coverage/lcov.info` and uploads it to Codecov.
 
-Current version: **1.0.286**
+Current version: **1.0.287**
 
-## 📋 Latest Changes (v1.0.286)
+## 📋 Latest Changes (v1.0.287)
 
 ### Bug Fixes
 
-- **infra:** add --kill-after to exec timeouts and extend SSM poll budget ([770d364](https://github.com/alternun-development/alternun/commit/770d3640df495f85c06ccd22947b06cb98722c72))
+- **infra:** sst-deploy ([721170d](https://github.com/alternun-development/alternun/commit/721170d578c2411d4242a778e76a1380fd6ad7d6))
 
 For full version history, see [CHANGELOG.md](./CHANGELOG.md) and [GitHub releases](https://github.com/alternun-development/alternun/releases)
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/admin",
-  "version": "1.0.287",
+  "version": "1.0.288",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/admin",
-  "version": "1.0.286",
+  "version": "1.0.287",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/api",
-  "version": "1.0.287",
+  "version": "1.0.288",
   "private": true,
   "scripts": {
     "dev": "nodemon --watch src --ext ts --signal SIGTERM --exec \"node -r ts-node/register/transpile-only src/main.ts\"",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/api",
-  "version": "1.0.286",
+  "version": "1.0.287",
   "private": true,
   "scripts": {
     "dev": "nodemon --watch src --ext ts --signal SIGTERM --exec \"node -r ts-node/register/transpile-only src/main.ts\"",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun-docs",
-  "version": "1.0.286",
+  "version": "1.0.287",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun-docs",
-  "version": "1.0.287",
+  "version": "1.0.288",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "test-tempo",
     "slug": "test-tempo",
-    "version": "1.0.286",
+    "version": "1.0.287-dev.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "test-tempo",
     "slug": "test-tempo",
-    "version": "1.0.287-dev.0",
+    "version": "1.0.288-dev.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alternun/mobile",
   "main": "expo-router/entry",
-  "version": "1.0.286",
+  "version": "1.0.287",
   "scripts": {
     "start": "pnpm --filter alternun changelog:sync && expo start",
     "build": "./build.sh",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alternun/mobile",
   "main": "expo-router/entry",
-  "version": "1.0.287",
+  "version": "1.0.288",
   "scripts": {
     "start": "pnpm --filter alternun changelog:sync && expo start",
     "build": "./build.sh",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/web",
-  "version": "1.0.286",
+  "version": "1.0.287",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/web",
-  "version": "1.0.287",
+  "version": "1.0.288",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun",
-  "version": "1.0.287",
+  "version": "1.0.288",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun",
-  "version": "1.0.286",
+  "version": "1.0.287",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/auth",
-  "version": "1.0.286",
+  "version": "1.0.287",
   "description": "Alternun auth wrapper package built on top of @edcalderon/auth",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/auth",
-  "version": "1.0.287",
+  "version": "1.0.288",
   "description": "Alternun auth wrapper package built on top of @edcalderon/auth",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/i18n",
-  "version": "1.0.286",
+  "version": "1.0.287",
   "description": "Shared translation catalogs and locale helpers for Alternun apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/i18n",
-  "version": "1.0.287",
+  "version": "1.0.288",
   "description": "Shared translation catalogs and locale helpers for Alternun apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/infra",
-  "version": "1.0.286",
+  "version": "1.0.287",
   "private": true,
   "type": "module",
   "description": "Alternun AWS/SST infrastructure wrapper for Expo web deployments.",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/infra",
-  "version": "1.0.287",
+  "version": "1.0.288",
   "private": true,
   "type": "module",
   "description": "Alternun AWS/SST infrastructure wrapper for Expo web deployments.",

--- a/packages/infra/scripts/sst-deploy.sh
+++ b/packages/infra/scripts/sst-deploy.sh
@@ -1109,6 +1109,9 @@ sync_identity_runtime_templates() {
 
   sync_status=$(printf '%s' "$invocation_json" | jq -r '.Status')
   if [ "$sync_status" != "Success" ]; then
+    if [ "$(printf '%s' "$invocation_json" | jq -r '.StatusDetails // ""')" = "Undeliverable" ]; then
+      IDENTITY_INSTANCE_UNDELIVERABLE=1
+    fi
     echo "$invocation_json"
     echo "ERROR: Identity runtime sync failed." >&2
     return 1
@@ -1119,11 +1122,30 @@ sync_identity_runtime_templates() {
 }
 
 DEPLOY_LOG=$(mktemp)
+IDENTITY_INSTANCE_UNDELIVERABLE=0
 echo "Running sst deploy"
 if run_sst_deploy "$DEPLOY_LOG"; then
-  sync_identity_runtime_templates
+  if sync_identity_runtime_templates; then
+    rm -f "$DEPLOY_LOG"
+    exit 0
+  fi
+  if [ "${IDENTITY_INSTANCE_UNDELIVERABLE:-0}" = "1" ]; then
+    echo "Identity instance unreachable (Undeliverable). Running sst refresh to reconcile instance state..."
+    (
+      cd "$INFRA_DIR"
+      env SST_TELEMETRY_DISABLED=1 npx sst refresh --stage "$STACK"
+    )
+    echo "Retrying sst deploy after instance drift refresh..."
+    IDENTITY_INSTANCE_UNDELIVERABLE=0
+    if run_sst_deploy "$DEPLOY_LOG"; then
+      sync_identity_runtime_templates
+      rm -f "$DEPLOY_LOG"
+      exit 0
+    fi
+  fi
+  echo "sst deploy succeeded but identity sync failed." >&2
   rm -f "$DEPLOY_LOG"
-  exit 0
+  exit 1
 fi
 
 if should_attempt_bucket_drift_recovery "$DEPLOY_LOG"; then

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/ui",
-  "version": "1.0.286",
+  "version": "1.0.287",
   "description": "Common UI components for Alternun",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/ui",
-  "version": "1.0.287",
+  "version": "1.0.288",
   "description": "Common UI components for Alternun",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/update/package.json
+++ b/packages/update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/update",
-  "version": "1.0.286",
+  "version": "1.0.287",
   "description": "Shared release update detection and service worker helpers for Alternun web apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/update/package.json
+++ b/packages/update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/update",
-  "version": "1.0.287",
+  "version": "1.0.288",
   "description": "Shared release update detection and service worker helpers for Alternun web apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/version.development.json
+++ b/version.development.json
@@ -1,22 +1,22 @@
 {
-  "version": "1.0.286-dev.0",
+  "version": "1.0.287-dev.0",
   "build": 0,
-  "lastUpdated": "2026-06-27T16:11:48.394Z",
+  "lastUpdated": "2026-06-27T16:39:42.474Z",
   "environment": "development",
   "lastDeployment": {
     "id": "development-0",
-    "version": "1.0.286-dev.0",
+    "version": "1.0.287-dev.0",
     "build": 0,
-    "date": "2026-06-27T16:11:48.394Z",
-    "message": "Release 1.0.286-dev.0"
+    "date": "2026-06-27T16:39:42.474Z",
+    "message": "Release 1.0.287-dev.0"
   },
   "deploymentHistory": [
     {
       "id": "development-0",
-      "version": "1.0.286-dev.0",
+      "version": "1.0.287-dev.0",
       "build": 0,
-      "date": "2026-06-27T16:11:48.394Z",
-      "message": "Release 1.0.286-dev.0"
+      "date": "2026-06-27T16:39:42.474Z",
+      "message": "Release 1.0.287-dev.0"
     },
     {
       "id": "development-1",

--- a/version.development.json
+++ b/version.development.json
@@ -1,22 +1,22 @@
 {
-  "version": "1.0.287-dev.0",
+  "version": "1.0.288-dev.0",
   "build": 0,
-  "lastUpdated": "2026-06-27T16:39:42.474Z",
+  "lastUpdated": "2026-06-27T16:41:54.619Z",
   "environment": "development",
   "lastDeployment": {
     "id": "development-0",
-    "version": "1.0.287-dev.0",
+    "version": "1.0.288-dev.0",
     "build": 0,
-    "date": "2026-06-27T16:39:42.474Z",
-    "message": "Release 1.0.287-dev.0"
+    "date": "2026-06-27T16:41:54.619Z",
+    "message": "Release 1.0.288-dev.0"
   },
   "deploymentHistory": [
     {
       "id": "development-0",
-      "version": "1.0.287-dev.0",
+      "version": "1.0.288-dev.0",
       "build": 0,
-      "date": "2026-06-27T16:39:42.474Z",
-      "message": "Release 1.0.287-dev.0"
+      "date": "2026-06-27T16:41:54.619Z",
+      "message": "Release 1.0.288-dev.0"
     },
     {
       "id": "development-1",


### PR DESCRIPTION
## Summary
- Promotes v1.0.287-dev.0 to master
- Fix: identity EC2 instance drift recovery — when SSM returns `Undeliverable` (terminated instance), `sst-deploy.sh` now auto-runs `sst refresh` + redeploy to recreate the instance before retrying the sync

## Changes
- `fix(infra): sst-deploy` — detect `Undeliverable` SSM status, set flag, trigger `sst refresh` + redeploy recovery path

## Test plan
- [ ] Infra tests pass (37/37)
- [ ] `identity-dev` pipeline self-heals on next run (instance will be recreated)
- [ ] `identity-prod` pipeline unaffected (instance is live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)