### PR TITLE
chore: release v1.0.288

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.0.288](https://github.com/alternun-development/alternun/compare/v1.0.287-dev.0...v1.0.288) (2026-06-27)
+
+### Bug Fixes
+
+- **repo:** docs: sync root README for v1.0.288
+
+
+
+
+
+
 ## [1.0.288](https://github.com/alternun-development/alternun/compare/v1.0.286...v1.0.288) (2026-06-27)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -118,9 +118,14 @@ pnpm version:check-secrets # scan staged files for secrets
 The root README is kept aligned with the current release state by the local README maintenance hook. `pnpm version:validate` now includes the README guard, and the release flow refreshes the version line, latest changes block, and support contact automatically.
 The CI test job now generates `apps/mobile/coverage/lcov.info` and uploads it to Codecov.
 
-Current version: **1.0.287**
+Current version: **1.0.288**
 
-## 📋 Latest Changes (v1.0.287)
+## 📋 Latest Changes (v1.0.288)
+
+### Bug Fixes
+
+- **repo:** chore(repo,admin,api): CHANGELOG, README, app, version.development
+- **repo:** fix(infra): sst-deploy
 
 ### Bug Fixes
 

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "test-tempo",
     "slug": "test-tempo",
-    "version": "1.0.288-dev.0",
+    "version": "1.0.288",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",

--- a/version.production.json
+++ b/version.production.json
@@ -1,16 +1,23 @@
 {
-  "version": "1.0.286",
-  "build": 31,
-  "lastUpdated": "2026-06-27T16:15:51.818Z",
+  "version": "1.0.288",
+  "build": 32,
+  "lastUpdated": "2026-06-27T17:01:42.545Z",
   "environment": "production",
   "lastDeployment": {
-    "id": "production-31",
-    "version": "1.0.286",
-    "build": 31,
-    "date": "2026-06-27T16:15:51.818Z",
-    "message": "Release 1.0.286"
+    "id": "production-32",
+    "version": "1.0.288",
+    "build": 32,
+    "date": "2026-06-27T17:01:42.545Z",
+    "message": "Release 1.0.288"
   },
   "deploymentHistory": [
+    {
+      "id": "production-32",
+      "version": "1.0.288",
+      "build": 32,
+      "date": "2026-06-27T17:01:42.545Z",
+      "message": "Release 1.0.288"
+    },
     {
       "id": "production-31",
       "version": "1.0.286",


### PR DESCRIPTION
## Summary
- Promotes v1.0.287-dev.0 → v1.0.288 production release
- README synced to v1.0.288
- Tag `v1.0.288` already pushed

## Changes included
- `fix(infra): sst-deploy` — identity EC2 instance drift recovery: auto `sst refresh` + redeploy when SSM returns `Undeliverable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)