### PR TITLE
chore: release v1.0.290

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
+## [1.0.290](https://github.com/alternun-development/alternun/compare/v1.0.289...v1.0.290) (2026-06-28)
+
+### Bug Fixes
+
+- **repo:** docs: sync root README for v1.0.289
+- **repo:** fix(identity): wait for SSM agent online before dispatching runtime sync
+
+### Bug Fixes
+
+- **identity:** wait for SSM agent online before dispatching runtime sync ([848da7d](https://github.com/alternun-development/alternun/commit/848da7d74dec52ce8fe774e126550f7c7d27006c))
+
 ## [1.0.289](https://github.com/alternun-development/alternun/compare/v1.0.289-dev.0...v1.0.289) (2026-06-27)
 
 ### Bug Fixes
 
 - **repo:** docs: sync root README for v1.0.289
-
-
-
-
-
 
 ## [1.0.289](https://github.com/alternun-development/alternun/compare/v1.0.287-dev.0...v1.0.289) (2026-06-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.0.289](https://github.com/alternun-development/alternun/compare/v1.0.289-dev.0...v1.0.289) (2026-06-27)
+
+### Bug Fixes
+
+- **repo:** docs: sync root README for v1.0.289
+
+
+
+
+
+
 ## [1.0.289](https://github.com/alternun-development/alternun/compare/v1.0.287-dev.0...v1.0.289) (2026-06-27)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.0.289](https://github.com/alternun-development/alternun/compare/v1.0.287-dev.0...v1.0.289) (2026-06-27)
+
+### Bug Fixes
+
+- **repo:** docs: sync root README for v1.0.288
+- **repo:** fix(identity): replace manage.py shell readiness check with HTTP health endpoint
+
+### Bug Fixes
+
+- **identity:** replace manage.py shell readiness check with HTTP health endpoint ([7dbea82](https://github.com/alternun-development/alternun/commit/7dbea824443ba73ff9dbc37ed83e1c427039b96b))
+
 ## [1.0.288](https://github.com/alternun-development/alternun/compare/v1.0.286...v1.0.288) (2026-06-27)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.0.291](https://github.com/alternun-development/alternun/compare/v1.0.290-dev.0...v1.0.291) (2026-06-28)
+
+### Bug Fixes
+
+- **repo:** docs: sync root README for v1.0.290
+- **repo:** fix(identity): fix container IP lookup and increase verify script timeout
+
+### Bug Fixes
+
+- **identity:** fix container IP lookup and increase verify script timeout ([c15e458](https://github.com/alternun-development/alternun/commit/c15e458597d7a70857687518c9f1e7909203b14b))
+
 ## [1.0.290](https://github.com/alternun-development/alternun/compare/v1.0.289...v1.0.290) (2026-06-28)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -118,18 +118,13 @@ pnpm version:check-secrets # scan staged files for secrets
 The root README is kept aligned with the current release state by the local README maintenance hook. `pnpm version:validate` now includes the README guard, and the release flow refreshes the version line, latest changes block, and support contact automatically.
 The CI test job now generates `apps/mobile/coverage/lcov.info` and uploads it to Codecov.
 
-Current version: **1.0.288**
+Current version: **1.0.289**
 
-## 📋 Latest Changes (v1.0.288)
-
-### Bug Fixes
-
-- **repo:** chore(repo,admin,api): CHANGELOG, README, app, version.development
-- **repo:** fix(infra): sst-deploy
+## 📋 Latest Changes (v1.0.289)
 
 ### Bug Fixes
 
-- **infra:** sst-deploy ([721170d](https://github.com/alternun-development/alternun/commit/721170d578c2411d4242a778e76a1380fd6ad7d6))
+- **identity:** replace manage.py shell readiness check with HTTP health endpoint ([7dbea82](https://github.com/alternun-development/alternun/commit/7dbea824443ba73ff9dbc37ed83e1c427039b96b))
 
 For full version history, see [CHANGELOG.md](./CHANGELOG.md) and [GitHub releases](https://github.com/alternun-development/alternun/releases)
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,14 @@ pnpm version:check-secrets # scan staged files for secrets
 The root README is kept aligned with the current release state by the local README maintenance hook. `pnpm version:validate` now includes the README guard, and the release flow refreshes the version line, latest changes block, and support contact automatically.
 The CI test job now generates `apps/mobile/coverage/lcov.info` and uploads it to Codecov.
 
-Current version: **1.0.287**
+Current version: **1.0.288**
 
-## 📋 Latest Changes (v1.0.287)
+## 📋 Latest Changes (v1.0.288)
+
+### Bug Fixes
+
+- **repo:** chore(repo,admin,api): CHANGELOG, README, app, version.development
+- **repo:** fix(infra): sst-deploy
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -118,13 +118,18 @@ pnpm version:check-secrets # scan staged files for secrets
 The root README is kept aligned with the current release state by the local README maintenance hook. `pnpm version:validate` now includes the README guard, and the release flow refreshes the version line, latest changes block, and support contact automatically.
 The CI test job now generates `apps/mobile/coverage/lcov.info` and uploads it to Codecov.
 
-Current version: **1.0.289**
+Current version: **1.0.290**
 
-## 📋 Latest Changes (v1.0.289)
+## 📋 Latest Changes (v1.0.290)
 
 ### Bug Fixes
 
 - **repo:** docs: sync root README for v1.0.289
+- **repo:** fix(identity): wait for SSM agent online before dispatching runtime sync
+
+### Bug Fixes
+
+- **identity:** wait for SSM agent online before dispatching runtime sync ([848da7d](https://github.com/alternun-development/alternun/commit/848da7d74dec52ce8fe774e126550f7c7d27006c))
 
 For full version history, see [CHANGELOG.md](./CHANGELOG.md) and [GitHub releases](https://github.com/alternun-development/alternun/releases)
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Current version: **1.0.289**
 
 ### Bug Fixes
 
-- **identity:** replace manage.py shell readiness check with HTTP health endpoint ([7dbea82](https://github.com/alternun-development/alternun/commit/7dbea824443ba73ff9dbc37ed83e1c427039b96b))
+- **repo:** docs: sync root README for v1.0.289
 
 For full version history, see [CHANGELOG.md](./CHANGELOG.md) and [GitHub releases](https://github.com/alternun-development/alternun/releases)
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/admin",
-  "version": "1.0.290",
+  "version": "1.0.291",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/admin",
-  "version": "1.0.288",
+  "version": "1.0.289",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/admin",
-  "version": "1.0.289",
+  "version": "1.0.290",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/api",
-  "version": "1.0.290",
+  "version": "1.0.291",
   "private": true,
   "scripts": {
     "dev": "nodemon --watch src --ext ts --signal SIGTERM --exec \"node -r ts-node/register/transpile-only src/main.ts\"",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/api",
-  "version": "1.0.289",
+  "version": "1.0.290",
   "private": true,
   "scripts": {
     "dev": "nodemon --watch src --ext ts --signal SIGTERM --exec \"node -r ts-node/register/transpile-only src/main.ts\"",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/api",
-  "version": "1.0.288",
+  "version": "1.0.289",
   "private": true,
   "scripts": {
     "dev": "nodemon --watch src --ext ts --signal SIGTERM --exec \"node -r ts-node/register/transpile-only src/main.ts\"",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun-docs",
-  "version": "1.0.288",
+  "version": "1.0.289",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun-docs",
-  "version": "1.0.290",
+  "version": "1.0.291",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun-docs",
-  "version": "1.0.289",
+  "version": "1.0.290",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "test-tempo",
     "slug": "test-tempo",
-    "version": "1.0.289",
+    "version": "1.0.290-dev.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "test-tempo",
     "slug": "test-tempo",
-    "version": "1.0.289-dev.0",
+    "version": "1.0.289",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "test-tempo",
     "slug": "test-tempo",
-    "version": "1.0.288-dev.0",
+    "version": "1.0.289-dev.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "test-tempo",
     "slug": "test-tempo",
-    "version": "1.0.290-dev.0",
+    "version": "1.0.291-dev.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alternun/mobile",
   "main": "expo-router/entry",
-  "version": "1.0.288",
+  "version": "1.0.289",
   "scripts": {
     "start": "pnpm --filter alternun changelog:sync && expo start",
     "build": "./build.sh",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alternun/mobile",
   "main": "expo-router/entry",
-  "version": "1.0.289",
+  "version": "1.0.290",
   "scripts": {
     "start": "pnpm --filter alternun changelog:sync && expo start",
     "build": "./build.sh",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alternun/mobile",
   "main": "expo-router/entry",
-  "version": "1.0.290",
+  "version": "1.0.291",
   "scripts": {
     "start": "pnpm --filter alternun changelog:sync && expo start",
     "build": "./build.sh",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/web",
-  "version": "1.0.288",
+  "version": "1.0.289",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/web",
-  "version": "1.0.290",
+  "version": "1.0.291",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/web",
-  "version": "1.0.289",
+  "version": "1.0.290",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun",
-  "version": "1.0.289",
+  "version": "1.0.290",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun",
-  "version": "1.0.288",
+  "version": "1.0.289",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun",
-  "version": "1.0.290",
+  "version": "1.0.291",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/auth",
-  "version": "1.0.289",
+  "version": "1.0.290",
   "description": "Alternun auth wrapper package built on top of @edcalderon/auth",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/auth",
-  "version": "1.0.290",
+  "version": "1.0.291",
   "description": "Alternun auth wrapper package built on top of @edcalderon/auth",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/auth",
-  "version": "1.0.288",
+  "version": "1.0.289",
   "description": "Alternun auth wrapper package built on top of @edcalderon/auth",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/i18n",
-  "version": "1.0.289",
+  "version": "1.0.290",
   "description": "Shared translation catalogs and locale helpers for Alternun apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/i18n",
-  "version": "1.0.290",
+  "version": "1.0.291",
   "description": "Shared translation catalogs and locale helpers for Alternun apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/i18n",
-  "version": "1.0.288",
+  "version": "1.0.289",
   "description": "Shared translation catalogs and locale helpers for Alternun apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/infra",
-  "version": "1.0.288",
+  "version": "1.0.289",
   "private": true,
   "type": "module",
   "description": "Alternun AWS/SST infrastructure wrapper for Expo web deployments.",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/infra",
-  "version": "1.0.290",
+  "version": "1.0.291",
   "private": true,
   "type": "module",
   "description": "Alternun AWS/SST infrastructure wrapper for Expo web deployments.",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/infra",
-  "version": "1.0.289",
+  "version": "1.0.290",
   "private": true,
   "type": "module",
   "description": "Alternun AWS/SST infrastructure wrapper for Expo web deployments.",

--- a/packages/infra/scripts/sst-deploy.sh
+++ b/packages/infra/scripts/sst-deploy.sh
@@ -1057,7 +1057,7 @@ sync_identity_runtime_templates() {
       --arg c14 'chown ec2-user:ec2-user /opt/alternun/identity/templates/docker-compose.ec2.yml /opt/alternun/identity/templates/docker-compose.rds.yml /opt/alternun/identity/templates/docker-compose.ec2.alb.yml /opt/alternun/identity/templates/docker-compose.rds.alb.yml /opt/alternun/identity/templates/bootstrap-authentik-integrations.py /opt/alternun/identity/authentik/custom-templates/alternun-bootstrap-integrations.py /opt/alternun/identity/templates/verify-authentik-runtime.sh' \
       --arg c15 'timeout 1800 bash /opt/alternun/identity/deploy-authentik.sh > /tmp/alternun-identity-runtime-sync.log 2>&1 || { cat /tmp/alternun-identity-runtime-sync.log; exit 1; }' \
       --arg c16 "grep -E 'Authentik integration bootstrap|Supabase auth OIDC synced|TLS certificate ready|Restored ACME state|WARN:' /tmp/alternun-identity-runtime-sync.log || true" \
-      --arg c17 'timeout 120 bash /opt/alternun/identity/templates/verify-authentik-runtime.sh' \
+      --arg c17 'timeout 360 bash /opt/alternun/identity/templates/verify-authentik-runtime.sh' \
       '{commands:[$c1,$c2,$c3,$c4,$c5,$c6,$c7,$c8,$c9,$c10,$c11,$c12,$c13,$c14,$c15,$c16,$c17]}'
   )
 

--- a/packages/infra/scripts/sst-deploy.sh
+++ b/packages/infra/scripts/sst-deploy.sh
@@ -966,6 +966,28 @@ sync_identity_runtime_templates() {
   local instance_id deploy_b64 bootstrap_b64 verify_runtime_b64 ec2_compose_b64 rds_compose_b64 ec2_alb_compose_b64 rds_alb_compose_b64 identity_domain identity_ingress_mode identity_tls_mode identity_acme_email identity_route53_zone_id identity_acme_backup_bucket identity_acme_backup_prefix identity_root_domain identity_app_name identity_authentik_image_tag identity_database_mode identity_authentik_secret_name identity_database_credentials_secret_name identity_smtp_credentials_secret_name identity_jwt_signing_secret_name identity_integration_config_secret_name params_json command_id
   instance_id=$(resolve_identity_instance_id)
 
+  # Wait for the SSM agent to register and be reachable before sending commands.
+  # The agent can be transiently offline during boot, OOM recovery, or after a fresh
+  # instance launch — dispatching before it's Online yields Undeliverable.
+  local ssm_wait_attempt=1 ssm_wait_max=60 ssm_ping
+  while [ "$ssm_wait_attempt" -le "$ssm_wait_max" ]; do
+    ssm_ping=$(aws ssm describe-instance-information \
+      --filters "Key=InstanceIds,Values=${instance_id}" \
+      --query 'InstanceInformationList[0].PingStatus' \
+      --output text 2>/dev/null || echo "")
+    if [ "$ssm_ping" = "Online" ]; then
+      break
+    fi
+    echo "Waiting for SSM agent on ${instance_id} (status: ${ssm_ping:-unknown}, attempt ${ssm_wait_attempt}/${ssm_wait_max})..." >&2
+    sleep 10
+    ssm_wait_attempt=$((ssm_wait_attempt + 1))
+  done
+  if [ "$ssm_ping" != "Online" ]; then
+    echo "ERROR: SSM agent on ${instance_id} did not come online after $((ssm_wait_max * 10))s." >&2
+    IDENTITY_INSTANCE_UNDELIVERABLE=1
+    return 1
+  fi
+
   case "$stage_normalized" in
     identity-prod|identity-production|auth-prod|authentik-prod)
       identity_domain="${INFRA_IDENTITY_DOMAIN_PRODUCTION:-sso.${INFRA_ROOT_DOMAIN:-${DOMAIN_ROOT:-alternun.co}}}"

--- a/packages/infra/scripts/templates/deploy-authentik.sh
+++ b/packages/infra/scripts/templates/deploy-authentik.sh
@@ -528,9 +528,11 @@ wait_for_authentik_django() {
   local attempt=1
 
   while [ "${attempt}" -le "${max_attempts}" ]; do
-    if timeout --kill-after=3 15 "${compose_cmd[@]}" -f /opt/alternun/identity/docker-compose.yml exec -T \
-      server sh -lc '/ak-root/.venv/bin/python /manage.py shell -c "print(\"ok\")"' \
-      >/dev/null 2>&1; then
+    # Use the container's internal IP to hit Authentik's HTTP health endpoint from the host.
+    # This avoids spawning a full Python/Django process (manage.py shell takes >15s on t3.small).
+    local server_ip
+    server_ip=$(docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' identity-server-1 2>/dev/null | awk '{print $1}')
+    if [ -n "$server_ip" ] && curl -sf --connect-timeout 3 --max-time 8 "http://${server_ip}:9000/-/health/live/" >/dev/null 2>&1; then
       return 0
     fi
     sleep 10

--- a/packages/infra/scripts/templates/deploy-authentik.sh
+++ b/packages/infra/scripts/templates/deploy-authentik.sh
@@ -528,10 +528,15 @@ wait_for_authentik_django() {
   local attempt=1
 
   while [ "${attempt}" -le "${max_attempts}" ]; do
-    # Use the container's internal IP to hit Authentik's HTTP health endpoint from the host.
+    # Resolve the container by ID via compose (works with both docker-compose and docker compose,
+    # old/new naming conventions) then curl the HTTP health endpoint from the host.
     # This avoids spawning a full Python/Django process (manage.py shell takes >15s on t3.small).
-    local server_ip
-    server_ip=$(docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' identity-server-1 2>/dev/null | awk '{print $1}')
+    local container_id server_ip
+    container_id=$("${compose_cmd[@]}" -f /opt/alternun/identity/docker-compose.yml ps -q server 2>/dev/null | head -1)
+    server_ip=""
+    if [ -n "$container_id" ]; then
+      server_ip=$(docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' "$container_id" 2>/dev/null | awk '{print $1}')
+    fi
     if [ -n "$server_ip" ] && curl -sf --connect-timeout 3 --max-time 8 "http://${server_ip}:9000/-/health/live/" >/dev/null 2>&1; then
       return 0
     fi

--- a/packages/infra/scripts/templates/verify-authentik-runtime.sh
+++ b/packages/infra/scripts/templates/verify-authentik-runtime.sh
@@ -83,4 +83,4 @@ raise SystemExit(0 if admin_exists and default_app_exists and admin_oidc_app and
 PYEOF
 )
 
-printf '%s\n' "$verify_shell" | timeout --kill-after=5 120 "${compose_cmd[@]}" -f /opt/alternun/identity/docker-compose.yml exec -T server /ak-root/.venv/bin/python /manage.py shell
+printf '%s\n' "$verify_shell" | timeout --kill-after=10 290 "${compose_cmd[@]}" -f /opt/alternun/identity/docker-compose.yml exec -T server /ak-root/.venv/bin/python /manage.py shell

--- a/packages/infra/test/sst-deploy-env-bootstrap.test.ts
+++ b/packages/infra/test/sst-deploy-env-bootstrap.test.ts
@@ -48,7 +48,7 @@ void test('sst-deploy syncs identity runtime verification through a dedicated sc
   );
   assert.match(
     source,
-    /timeout 120 bash \/opt\/alternun\/identity\/templates\/verify-authentik-runtime\.sh/
+    /timeout 360 bash \/opt\/alternun\/identity\/templates\/verify-authentik-runtime\.sh/
   );
   assert.match(
     source,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/ui",
-  "version": "1.0.290",
+  "version": "1.0.291",
   "description": "Common UI components for Alternun",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/ui",
-  "version": "1.0.288",
+  "version": "1.0.289",
   "description": "Common UI components for Alternun",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/ui",
-  "version": "1.0.289",
+  "version": "1.0.290",
   "description": "Common UI components for Alternun",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/update/package.json
+++ b/packages/update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/update",
-  "version": "1.0.289",
+  "version": "1.0.290",
   "description": "Shared release update detection and service worker helpers for Alternun web apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/update/package.json
+++ b/packages/update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/update",
-  "version": "1.0.288",
+  "version": "1.0.289",
   "description": "Shared release update detection and service worker helpers for Alternun web apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/update/package.json
+++ b/packages/update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/update",
-  "version": "1.0.290",
+  "version": "1.0.291",
   "description": "Shared release update detection and service worker helpers for Alternun web apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/version.development.json
+++ b/version.development.json
@@ -1,22 +1,22 @@
 {
-  "version": "1.0.288-dev.0",
+  "version": "1.0.289-dev.0",
   "build": 0,
-  "lastUpdated": "2026-06-27T16:41:54.619Z",
+  "lastUpdated": "2026-06-27T23:07:48.287Z",
   "environment": "development",
   "lastDeployment": {
     "id": "development-0",
-    "version": "1.0.288-dev.0",
+    "version": "1.0.289-dev.0",
     "build": 0,
-    "date": "2026-06-27T16:41:54.619Z",
-    "message": "Release 1.0.288-dev.0"
+    "date": "2026-06-27T23:07:48.287Z",
+    "message": "Release 1.0.289-dev.0"
   },
   "deploymentHistory": [
     {
       "id": "development-0",
-      "version": "1.0.288-dev.0",
+      "version": "1.0.289-dev.0",
       "build": 0,
-      "date": "2026-06-27T16:41:54.619Z",
-      "message": "Release 1.0.288-dev.0"
+      "date": "2026-06-27T23:07:48.287Z",
+      "message": "Release 1.0.289-dev.0"
     },
     {
       "id": "development-1",

--- a/version.development.json
+++ b/version.development.json
@@ -1,22 +1,22 @@
 {
-  "version": "1.0.289-dev.0",
+  "version": "1.0.290-dev.0",
   "build": 0,
-  "lastUpdated": "2026-06-27T23:07:48.287Z",
+  "lastUpdated": "2026-06-28T00:16:16.588Z",
   "environment": "development",
   "lastDeployment": {
     "id": "development-0",
-    "version": "1.0.289-dev.0",
+    "version": "1.0.290-dev.0",
     "build": 0,
-    "date": "2026-06-27T23:07:48.287Z",
-    "message": "Release 1.0.289-dev.0"
+    "date": "2026-06-28T00:16:16.588Z",
+    "message": "Release 1.0.290-dev.0"
   },
   "deploymentHistory": [
     {
       "id": "development-0",
-      "version": "1.0.289-dev.0",
+      "version": "1.0.290-dev.0",
       "build": 0,
-      "date": "2026-06-27T23:07:48.287Z",
-      "message": "Release 1.0.289-dev.0"
+      "date": "2026-06-28T00:16:16.588Z",
+      "message": "Release 1.0.290-dev.0"
     },
     {
       "id": "development-1",

--- a/version.development.json
+++ b/version.development.json
@@ -1,22 +1,22 @@
 {
-  "version": "1.0.290-dev.0",
+  "version": "1.0.291-dev.0",
   "build": 0,
-  "lastUpdated": "2026-06-28T00:16:16.588Z",
+  "lastUpdated": "2026-06-28T00:58:46.836Z",
   "environment": "development",
   "lastDeployment": {
     "id": "development-0",
-    "version": "1.0.290-dev.0",
+    "version": "1.0.291-dev.0",
     "build": 0,
-    "date": "2026-06-28T00:16:16.588Z",
-    "message": "Release 1.0.290-dev.0"
+    "date": "2026-06-28T00:58:46.836Z",
+    "message": "Release 1.0.291-dev.0"
   },
   "deploymentHistory": [
     {
       "id": "development-0",
-      "version": "1.0.290-dev.0",
+      "version": "1.0.291-dev.0",
       "build": 0,
-      "date": "2026-06-28T00:16:16.588Z",
-      "message": "Release 1.0.290-dev.0"
+      "date": "2026-06-28T00:58:46.836Z",
+      "message": "Release 1.0.291-dev.0"
     },
     {
       "id": "development-1",

--- a/version.production.json
+++ b/version.production.json
@@ -1,16 +1,23 @@
 {
-  "version": "1.0.286",
-  "build": 31,
-  "lastUpdated": "2026-06-27T16:15:51.818Z",
+  "version": "1.0.289",
+  "build": 32,
+  "lastUpdated": "2026-06-27T23:12:13.300Z",
   "environment": "production",
   "lastDeployment": {
-    "id": "production-31",
-    "version": "1.0.286",
-    "build": 31,
-    "date": "2026-06-27T16:15:51.818Z",
-    "message": "Release 1.0.286"
+    "id": "production-32",
+    "version": "1.0.289",
+    "build": 32,
+    "date": "2026-06-27T23:12:13.300Z",
+    "message": "Release 1.0.289"
   },
   "deploymentHistory": [
+    {
+      "id": "production-32",
+      "version": "1.0.289",
+      "build": 32,
+      "date": "2026-06-27T23:12:13.300Z",
+      "message": "Release 1.0.289"
+    },
     {
       "id": "production-31",
       "version": "1.0.286",


### PR DESCRIPTION
## Summary

- fix(identity): replace `manage.py shell` readiness check in `wait_for_authentik_django` with lightweight HTTP health endpoint (`/-/health/live/`) — avoids spawning a full Python/Django process that times out on t3.small
- fix(identity): wait for SSM agent to report Online before dispatching runtime sync command batch — prevents Undeliverable failures when the agent is transiently offline during boot or container startup

## Test plan

- [ ] `alternun-auth-dev-pipeline` succeeds end-to-end
- [ ] `alternun-auth-prod-pipeline` succeeds end-to-end
- [ ] Both auth pipelines are InProgress as of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)