### PR TITLE
chore: release v1.1.3

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,24 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# Block release/* and promote/* branch pushes.
+# Per CLAUDE.md §11: all production releases go develop→master via direct PR.
+# No intermediate release or promote branches — they litter the repo and are
+# never cleaned up. Use develop directly.
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+case "$current_branch" in
+  release/*|release-*|promote/*)
+    echo ""
+    echo "❌  PUSH BLOCKED: branch '${current_branch}' is a release/promote branch."
+    echo ""
+    echo "    Per CLAUDE.md §11, production releases go directly develop → master."
+    echo "    Open a PR from 'develop' to 'master' instead."
+    echo "    Never create release/* or promote/* branches — delete this one."
+    echo ""
+    exit 1
+    ;;
+esac
+
 # Check versioning before push
 npm run version:validate
 npm run version:check-secrets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,7 +390,9 @@ identity; renaming breaks cross-references and git history.
 
 ## 11. Release Flow — develop → master (no release branches)
 
-**All production releases go directly from `develop` to `master` via a single PR. Never create `release/v*` branches.**
+**All production releases go directly from `develop` to `master` via a single PR. Never create `release/v*` or `promote/v*` branches.**
+
+> **Hard guard:** `.husky/pre-push` blocks any push to a branch matching `release/*`, `release-*`, or `promote/*` with an error message. This is enforced automatically — you cannot bypass it without editing the hook.
 
 ### The canonical flow
 
@@ -417,16 +419,14 @@ develop  ──── (work, commits) ────► PR #N ──► master ─
 
    This bumps all package.json versions, updates CHANGELOG, builds, creates the git tag, and pushes.
 
-3. **Open the PR from a temp branch if master is protected** (only if direct push fails):
+3. **If master push is blocked by branch protection**, push the release tag only and open the PR from `develop`:
 
    ```bash
-   git checkout -b promote/vX.Y.Z
-   git push origin promote/vX.Y.Z --follow-tags
-   gh pr create --base master --head promote/vX.Y.Z --title "chore: release vX.Y.Z"
-   # Merge via GitHub UI, then delete the branch immediately
+   git push origin v1.1.3  # push only the tag
+   gh pr create --base master --head develop --title "chore: release vX.Y.Z"
    ```
 
-   Delete `promote/vX.Y.Z` as soon as the PR merges — it must not persist.
+   **Do NOT create a separate branch.** `develop` is already the release candidate.
 
 4. **Sync master back to develop**:
    ```bash
@@ -437,13 +437,13 @@ develop  ──── (work, commits) ────► PR #N ──► master ─
 
 ### What NOT to do
 
-- ❌ Never create persistent `release/vX.Y.Z` branches — they litter the repo
-- ❌ Never release a patch from `develop` (`pnpm release patch` on develop creates dev builds, not production)
-- ❌ Never leave a promote branch after the PR merges — delete it immediately
+- ❌ Never create `release/vX.Y.Z` or `promote/vX.Y.Z` branches — the pre-push hook blocks this
+- ❌ Never release a patch from `develop` (`pnpm release patch` on develop creates dev builds)
+- ❌ Never open a PR from a release or promote branch — always PR from `develop`
 
 ### Guards (enforced automatically)
 
+- **`.husky/pre-push`**: blocks any push to `release/*`, `release-*`, `promote/*` branches with a clear error
 - `pnpm release` on `develop` → creates dev releases only (e.g. `1.1.2-dev.0`)
 - `pnpm release patch` on `master` → creates production patch releases (e.g. `1.1.2`)
-- Pre-push hook validates: AWS account, version sync, secrets scan, changelog entry, reentry status
-- If push to master is rejected (branch protection): use a `promote/vX.Y.Z` branch, merge via PR, delete immediately
+- Pre-push hook also validates: AWS account, version sync, secrets scan, changelog entry, reentry status

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -4,6 +4,7 @@ import { AirsModule } from './modules/airs/airs.module';
 import { AuthExchangeModule } from './modules/auth-exchange/auth-exchange.module';
 import { AuthentikModule } from './modules/authentik/authentik.module';
 import { DecapModule } from './modules/decap/decap.module';
+import { GeoModule } from './modules/geo/geo.module';
 import { HealthModule } from './modules/health/health.module';
 import { LegalModule } from './modules/legal/legal.module';
 import { ReferralsModule } from './modules/referrals/referrals.module';
@@ -17,6 +18,7 @@ import { WalletModule } from './modules/wallet/wallet.module';
     AuthExchangeModule,
     AirsModule,
     ActivityModule,
+    GeoModule,
     LegalModule,
     ReferralsModule,
     WalletModule,

--- a/apps/api/src/modules/geo/geo.controller.ts
+++ b/apps/api/src/modules/geo/geo.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Get, Ip, InternalServerErrorException } from '@nestjs/common';
+
+interface IpapiResponse {
+  country_name?: string;
+  country_code?: string;
+  city?: string;
+}
+
+@Controller('v1/geo')
+export class GeoController {
+  @Get()
+  async locate(
+    @Ip() clientIp: string
+  ): Promise<{ countryName: string; countryCode: string; city: string }> {
+    const key = process.env.IPAPI_ACCESS;
+    // Use the client's IP so the lookup reflects the actual requester location.
+    // Fall back to /json/ (auto-detect) when running locally without a routable IP.
+    const url = key
+      ? `https://ipapi.co/${encodeURIComponent(clientIp)}/json/?key=${key}`
+      : 'https://ipapi.co/json/';
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) throw new InternalServerErrorException('Geo lookup failed');
+      const data = (await res.json()) as IpapiResponse;
+      return {
+        countryName: data.country_name ?? '',
+        countryCode: data.country_code ?? '',
+        city: data.city ?? '',
+      };
+    } catch (err) {
+      if (err instanceof InternalServerErrorException) throw err;
+      throw new InternalServerErrorException('Geo lookup unavailable');
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/apps/api/src/modules/geo/geo.module.ts
+++ b/apps/api/src/modules/geo/geo.module.ts
@@ -1,0 +1,5 @@
+import { Module } from '@nestjs/common';
+import { GeoController } from './geo.controller';
+
+@Module({ controllers: [GeoController] })
+export class GeoModule {}

--- a/apps/mobile/app/mi-perfil.tsx
+++ b/apps/mobile/app/mi-perfil.tsx
@@ -3161,27 +3161,8 @@ export default function MiPerfilScreen(): React.JSX.Element {
   if (loading) return <ActivityIndicator size='large' color={c.accent} style={{ flex: 1 }} />;
 
   if (!user) {
-    return (
-      <View style={[styles.center, { backgroundColor: c.bg }]}>
-        <GlassCard style={{ alignItems: 'center' }}>
-          <UserCircle2Icon size={48} color={c.muted} />
-          <Text style={[styles.signInPrompt, { color: c.text }]}>
-            {t('profile.signInPrompt', undefined, 'Sign in to view your profile')}
-          </Text>
-          <TouchableOpacity
-            style={[
-              styles.signInBtn,
-              { backgroundColor: `${c.accent}18`, borderColor: `${c.accent}44` },
-            ]}
-            onPress={() => router.push('/auth?next=/mi-perfil')}
-          >
-            <Text style={[styles.signInBtnText, { color: c.accent }]}>
-              {t('shared.labels.signIn', undefined, 'Sign In')}
-            </Text>
-          </TouchableOpacity>
-        </GlassCard>
-      </View>
-    );
+    router.replace('/');
+    return null;
   }
 
   return (

--- a/apps/mobile/utils/geolocation.ts
+++ b/apps/mobile/utils/geolocation.ts
@@ -1,3 +1,5 @@
+import { resolveMobileApiBaseUrl } from './runtimeConfig';
+
 export interface GeoLocation {
   countryName: string;
   countryCode: string;
@@ -9,11 +11,12 @@ export async function detectLocationFromIP(): Promise<GeoLocation | null> {
   const timeout = setTimeout(() => controller.abort(), 5000);
 
   try {
-    const res = await fetch('https://ipapi.co/json/', { signal: controller.signal });
+    const base = resolveMobileApiBaseUrl();
+    const res = await fetch(`${base}/v1/geo`, { signal: controller.signal });
     if (!res.ok) return null;
     const data = (await res.json()) as Record<string, unknown>;
-    const countryName = typeof data.country_name === 'string' ? data.country_name.trim() : null;
-    const countryCode = typeof data.country_code === 'string' ? data.country_code.trim() : '';
+    const countryName = typeof data.countryName === 'string' ? data.countryName.trim() : null;
+    const countryCode = typeof data.countryCode === 'string' ? data.countryCode.trim() : '';
     const city = typeof data.city === 'string' ? data.city.trim() : null;
     if (!countryName || !city) return null;
     return { countryName, countryCode, city };

--- a/packages/infra/modules/backend-api.ts
+++ b/packages/infra/modules/backend-api.ts
@@ -495,6 +495,11 @@ export function deployBackendApiInfrastructure(
             : args.env.SUPABASE_SERVICE_ROLE_KEY
             ? { SUPABASE_SERVICE_ROLE_KEY: args.env.SUPABASE_SERVICE_ROLE_KEY }
             : {}),
+          ...(args.env.INFRA_BACKEND_API_IPAPI_ACCESS
+            ? { IPAPI_ACCESS: args.env.INFRA_BACKEND_API_IPAPI_ACCESS }
+            : args.env.IPAPI_ACCESS
+            ? { IPAPI_ACCESS: args.env.IPAPI_ACCESS }
+            : {}),
           AUTHENTIK_SMTP_SECRET_ARN: smtpSecretArn,
           AIRS_SMTP_SECRET_ARN: smtpSecretArn,
           ...(args.env.INFRA_BACKEND_API_AUTH_EMAIL_FROM

--- a/packages/infra/scripts/resolve-ssm-env.sh
+++ b/packages/infra/scripts/resolve-ssm-env.sh
@@ -55,6 +55,7 @@ if [ "${CODEBUILD_BUILD_ID:-}" != "" ] || [ "${CI:-}" = "true" ] || [ "${APPROVE
     INFRA_BACKEND_API_SUPABASE_URL \
     INFRA_BACKEND_API_SUPABASE_ANON_KEY \
     INFRA_BACKEND_API_SUPABASE_SERVICE_ROLE_KEY \
+    INFRA_BACKEND_API_IPAPI_ACCESS \
     AUTH_EXECUTION_PROVIDER \
     EXPO_PUBLIC_AUTH_EXECUTION_PROVIDER \
     DATABASE_URL \
@@ -404,6 +405,7 @@ main() {
   export_env_from_ssm "INFRA_BACKEND_API_SUPABASE_URL" "expo-public-supabase-url" "" "${SSM_SHARED_STAGE}"
   export_env_from_ssm "INFRA_BACKEND_API_SUPABASE_ANON_KEY" "expo-public-supabase-key" "" "${SSM_SHARED_STAGE}"
   export_env_from_ssm "INFRA_BACKEND_API_SUPABASE_SERVICE_ROLE_KEY" "supabase-service-role-key" "" "${SSM_SHARED_STAGE}"
+  export_env_from_ssm "INFRA_BACKEND_API_IPAPI_ACCESS" "ipapi-key" "" "${SSM_SHARED_STAGE}"
   export_env_from_ssm "EXPO_PUBLIC_WALLETCONNECT_PROJECT_ID" "expo-public-walletconnect-project-id" "" "${SSM_SHARED_STAGE}"
   export_env_from_ssm "EXPO_PUBLIC_AUTHENTIK_ISSUER" "expo-public-authentik-issuer" "" "${SSM_SHARED_STAGE}"
   export_env_from_ssm "EXPO_PUBLIC_AUTHENTIK_CLIENT_ID" "expo-public-authentik-client-id" "" "${SSM_SHARED_STAGE}"

--- a/packages/infra/scripts/resolve-ssm-env.sh
+++ b/packages/infra/scripts/resolve-ssm-env.sh
@@ -43,9 +43,10 @@ declare -a CACHE_EXPORT_VARS=(
   DATABASE_URL
 )
 
-# CI shells can inherit stale auth values from the CodeBuild project.
-# Clear the stage contract vars so SSM/default stage resolution wins.
-if [ "${CODEBUILD_BUILD_ID:-}" != "" ] || [ "${CI:-}" = "true" ]; then
+# CI shells and approved local deploys (APPROVE=true) can carry stale local-dev
+# auth values (e.g. localhost:8082 from .env). Clear the stage contract vars so
+# SSM/default stage resolution wins — the deployed stage URL is authoritative.
+if [ "${CODEBUILD_BUILD_ID:-}" != "" ] || [ "${CI:-}" = "true" ] || [ "${APPROVE:-}" = "true" ]; then
   unset \
     EXPO_PUBLIC_API_URL \
     EXPO_PUBLIC_SUPABASE_URL \


### PR DESCRIPTION
## Summary

- **fix(prod-api-500):** Production Lambda now has `SUPABASE_SERVICE_ROLE_KEY` — fixes 500 on wallet/accounts, airs/me, airs/onboarding
- **fix(auth-env):** Testnet bundle was baking in production API URLs; `resolve-ssm-env.sh` now clears local overrides when `APPROVE=true`
- **fix(ui):** `/mi-perfil` redirects to `/` when signed out
- **feat(geo):** Server-side IP geolocation proxy at `GET /v1/geo`; `IPAPI_ACCESS` in SSM only, never client-side
- **infra:** Guard added to pre-push hook to block `release/*` and `promote/*` branch pushes

## Test plan

- [ ] After merge: wallet/accounts, airs/me return 200 for authenticated prod users
- [ ] testnet.airs.alternun.co Google/Discord buttons enabled
- [ ] `/v1/geo` returns location on both environments
- [ ] `git push origin release/anything` is blocked by pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)