### PR TITLE
fix(db): v1.1.3 — AIRS PGRST203 fix and wallet DB migrations for prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [1.1.3](https://github.com/alternun-development/alternun/compare/v1.1.2...v1.1.3) (2026-07-01)
+
+### Bug Fixes
+
+- **repo:** fix(db): force-drop stale AIRS uuid overloads causing PGRST203 ambiguity
+- **repo:** chore: set develop to 1.1.2-dev.0 after production release --no-validate-reentry
+- **repo:** chore: sync roadmap --no-validate-reentry
+- **repo:** chore: sync version files for v1.1.2 --no-validate-reentry
+- **repo:** docs(agents): add geo-service pending task — self-hosted MaxMind GeoLite2 to replace ipapi.co
+
+### Bug Fixes
+
+- **db:** force-drop stale AIRS uuid overloads causing PGRST203 ambiguity ([6c81fd5](https://github.com/alternun-development/alternun/commit/6c81fd592b14ec229a4827014e324723b4fbf381))
+
 ## [1.1.2](https://github.com/alternun-development/alternun/compare/v1.1.0...v1.1.2) (2026-07-01)
 
 ### Bug Fixes

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/admin",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/api",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "scripts": {
     "dev": "nodemon --watch src --ext ts --signal SIGTERM --exec \"node -r ts-node/register/transpile-only src/main.ts\"",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun-docs",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "test-tempo",
     "slug": "test-tempo",
-    "version": "1.1.2",
+    "version": "1.1.3-dev.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alternun/mobile",
   "main": "expo-router/entry",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "scripts": {
     "start": "pnpm --filter alternun changelog:sync && expo start",
     "build": "./build.sh",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/web",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alternun",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/auth",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Alternun auth wrapper package built on top of @edcalderon/auth",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/i18n",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Shared translation catalogs and locale helpers for Alternun apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/infra",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "type": "module",
   "description": "Alternun AWS/SST infrastructure wrapper for Expo web deployments.",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/ui",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Common UI components for Alternun",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/update/package.json
+++ b/packages/update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alternun/update",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Shared release update detection and service worker helpers for Alternun web apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/supabase/migrations/20260701_0001_force_drop_airs_uuid_overloads.sql
+++ b/supabase/migrations/20260701_0001_force_drop_airs_uuid_overloads.sql
@@ -1,0 +1,7 @@
+-- Force-drop the uuid overloads of AIRS functions that 20260626_0004 should have removed
+-- but didn't (the uuid overloads still exist in prod DB with OIDs 66639 and 66642,
+-- causing PGRST203 ambiguity — PostgREST can't choose between text and uuid overloads).
+-- 20260626_0004 is recorded in _migrations but the DROPs never took effect.
+
+drop function if exists public.airs_record_dashboard_visit(uuid, text, jsonb);
+drop function if exists public.airs_get_dashboard_snapshot(uuid, text, integer);

--- a/version.development.json
+++ b/version.development.json
@@ -1,29 +1,29 @@
 {
-  "version": "1.1.2-dev.0",
-  "build": 1,
-  "lastUpdated": "2026-07-01T17:52:46.000Z",
+  "version": "1.1.3-dev.0",
+  "build": 0,
+  "lastUpdated": "2026-07-01T19:48:05.782Z",
   "environment": "development",
   "lastDeployment": {
-    "id": "development-1",
-    "version": "1.1.1-dev.0",
-    "build": 1,
-    "date": "2026-07-01T11:31:17.000Z",
-    "message": "Sync to 1.1.1-dev.0 after production release v1.1.1"
+    "id": "development-0",
+    "version": "1.1.3-dev.0",
+    "build": 0,
+    "date": "2026-07-01T19:48:05.782Z",
+    "message": "Release 1.1.3-dev.0"
   },
   "deploymentHistory": [
+    {
+      "id": "development-0",
+      "version": "1.1.3-dev.0",
+      "build": 0,
+      "date": "2026-07-01T19:48:05.782Z",
+      "message": "Release 1.1.3-dev.0"
+    },
     {
       "id": "development-1",
       "version": "1.1.1-dev.0",
       "build": 1,
       "date": "2026-07-01T11:31:17.000Z",
       "message": "Sync to 1.1.1-dev.0 after production release v1.1.1"
-    },
-    {
-      "id": "development-0",
-      "version": "1.1.0-dev.0",
-      "build": 0,
-      "date": "2026-06-30T20:40:40.672Z",
-      "message": "Release 1.1.0-dev.0"
     },
     {
       "id": "development-1",


### PR DESCRIPTION
## 📝 Description

Release v1.1.3: Production hotfix for two API failures on `api.alternun.co`.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 🎯 Purpose

**Problem 1 — PGRST203 ambiguity on AIRS endpoints:**
`airs_record_dashboard_visit` and `airs_get_dashboard_snapshot` had both `text` and `uuid` overloads in prod. Migration `20260626_0004` was recorded in `_migrations` but the uuid overloads were never actually dropped, causing PostgREST to error with `PGRST203: Could not choose the best candidate function`.

Fix: New migration `20260701_0001_force_drop_airs_uuid_overloads` explicitly drops the uuid overloads with `IF EXISTS`.

**Problem 2 — Wallet setup/accounts 500 errors (applied directly to prod DB, not in this diff):**
- `wallet_accounts/wallet_preferences.user_id` was `uuid` type but `public.users.id` is `text` — FK violation on every insert
- Supabase service role key was missing from prod Lambda env — anon key was used, RLS blocked inserts
- Fixes applied: DB migrations `20260630_0001` and `20260630_0002` applied to prod; Lambda env patched; SSM params + CodeBuild updated for permanent fix

## 🧪 Testing

- [x] DB migrations applied and verified on both testnet and prod before this PR
- [x] Prod DB confirmed: only `text` overloads remain for AIRS functions (no PGRST203)
- [x] Prod DB confirmed: `wallet_accounts.user_id` and `wallet_preferences.user_id` are now `text`
- [x] v1.1.3 tag already pushed; release artifacts built locally

## 📋 Checklist

- [x] My code follows the project's coding standards and style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## 🔗 Related Issues

Fixes wallet setup 500 errors on `api.alternun.co` and `testnet.api.alternun.co`.
Fixes PGRST203 ambiguity on AIRS dashboard endpoints.

## 📝 Additional Notes

Permanent infrastructure fixes (SSM params, CodeBuild env, Lambda env) were applied out-of-band. The only code change in this PR is the new migration file that drops the stale uuid overloads.