### PR TITLE
🐛(auth): repair production signup provisioning

### DIFF
--- a/apps/api/src/modules/auth-exchange/services/signup.service.ts
+++ b/apps/api/src/modules/auth-exchange/services/signup.service.ts
@@ -108,12 +108,16 @@ export class SignupService {
             });
         }
 
-        this.sendSignupWelcomeEmailAsync(email, name, locale).catch((err) => {
-          this.logger.warn('Failed to send signup welcome email', {
-            email,
-            error: err instanceof Error ? err.message : String(err),
+        // Better Auth sends the same welcome message from its user-create hook.
+        // Avoid sending an identical second message when it owns the signup flow.
+        if (authApi.name !== 'better-auth') {
+          this.sendSignupWelcomeEmailAsync(email, name, locale).catch((err) => {
+            this.logger.warn('Failed to send signup welcome email', {
+              email,
+              error: err instanceof Error ? err.message : String(err),
+            });
           });
-        });
+        }
       }
 
       return normalized;

--- a/apps/api/test/airs-profile-bonus-text-rpc.migration.test.js
+++ b/apps/api/test/airs-profile-bonus-text-rpc.migration.test.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const migrationPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../supabase/migrations/20260818_0006_repair_text_profile_bonus_after_uuid_overload_cleanup.sql'
+);
+
+void test('the text profile-bonus RPC remains self-contained after UUID overload cleanup', () => {
+  const source = fs.readFileSync(migrationPath, 'utf8');
+
+  assert.match(source, /create or replace function public\.airs_award_profile_completion_bonus\(\s*p_user_id text/i);
+  assert.match(source, /v_entry := public\.airs_record_ledger_entry\(/);
+  assert.doesNotMatch(source, /from public\.airs_award_profile_completion_bonus\(\s*p_user_id::uuid/i);
+});

--- a/packages/infra/config/pipelines/specs/dashboard.ts
+++ b/packages/infra/config/pipelines/specs/dashboard.ts
@@ -80,6 +80,7 @@ export function buildDashboardPipelineSpecs({
         INFRA_BACKEND_API_SUPABASE_SERVICE_ROLE_KEY:
           env.INFRA_BACKEND_API_SUPABASE_SERVICE_ROLE_KEY ?? env.SUPABASE_SERVICE_ROLE_KEY ?? '',
         INFRA_BACKEND_API_AUTH_BETTER_AUTH_URL: betterAuthUrlDev,
+        INFRA_BACKEND_API_AUTH_SIGNUP_PROVIDER: 'better-auth',
         INFRA_BACKEND_API_DATABASE_URL: backendDatabaseUrl,
         AUTHENTIK_SMTP_SECRET_ARN: `${smtpSecretArn}/identity-dev`,
         AIRS_SMTP_SECRET_ARN: `${smtpSecretArn}/identity-dev`,
@@ -122,6 +123,7 @@ export function buildDashboardPipelineSpecs({
         INFRA_BACKEND_API_SUPABASE_SERVICE_ROLE_KEY:
           env.INFRA_BACKEND_API_SUPABASE_SERVICE_ROLE_KEY ?? env.SUPABASE_SERVICE_ROLE_KEY ?? '',
         INFRA_BACKEND_API_AUTH_BETTER_AUTH_URL: betterAuthUrlProd,
+        INFRA_BACKEND_API_AUTH_SIGNUP_PROVIDER: 'better-auth',
         INFRA_BACKEND_API_DATABASE_URL: backendDatabaseUrl,
         AUTHENTIK_SMTP_SECRET_ARN: `${smtpSecretArn}/identity-prod`,
         AIRS_SMTP_SECRET_ARN: `${smtpSecretArn}/identity-prod`,

--- a/packages/infra/modules/backend-api.ts
+++ b/packages/infra/modules/backend-api.ts
@@ -544,6 +544,11 @@ export function deployBackendApiInfrastructure(
                   args.env.INFRA_BACKEND_API_AUTH_BETTER_AUTH_REQUEST_TIMEOUT_MS,
               }
             : {}),
+          ...(args.env.INFRA_BACKEND_API_AUTH_SIGNUP_PROVIDER
+            ? { AUTH_SIGNUP_PROVIDER: args.env.INFRA_BACKEND_API_AUTH_SIGNUP_PROVIDER }
+            : args.env.AUTH_SIGNUP_PROVIDER
+            ? { AUTH_SIGNUP_PROVIDER: args.env.AUTH_SIGNUP_PROVIDER }
+            : {}),
           ...(args.env.INFRA_BACKEND_API_AUTH_EXCHANGE_REQUIRE_ISSUER_OWNED
             ? {
                 AUTH_EXCHANGE_REQUIRE_ISSUER_OWNED:

--- a/packages/infra/test/backend-api-better-auth-env.test.ts
+++ b/packages/infra/test/backend-api-better-auth-env.test.ts
@@ -9,6 +9,8 @@ void test('backend API module forwards Better Auth runtime env into the Lambda c
   const source = fs.readFileSync(backendApiModulePath, 'utf8');
 
   assert.match(source, /AUTH_BETTER_AUTH_URL/);
+  assert.match(source, /AUTH_SIGNUP_PROVIDER/);
+  assert.match(source, /INFRA_BACKEND_API_AUTH_SIGNUP_PROVIDER/);
   assert.match(source, /resolveBackendDatabaseUrl/);
   assert.match(source, /preferDedicatedBackendDatabase/);
   assert.match(source, /isTestnetStage\(env\.SST_STAGE \?\? env\.STACK\)/);

--- a/packages/infra/test/dashboard-signup-provider.test.ts
+++ b/packages/infra/test/dashboard-signup-provider.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const dashboardSpecPath = path.resolve('config/pipelines/specs/dashboard.ts');
+
+void test('dashboard deployments explicitly use Better Auth for email signup', () => {
+  const source = fs.readFileSync(dashboardSpecPath, 'utf8');
+
+  assert.match(source, /INFRA_BACKEND_API_AUTH_SIGNUP_PROVIDER:\s*'better-auth'/);
+});

--- a/supabase/migrations/20260818_0006_repair_text_profile_bonus_after_uuid_overload_cleanup.sql
+++ b/supabase/migrations/20260818_0006_repair_text_profile_bonus_after_uuid_overload_cleanup.sql
@@ -1,0 +1,134 @@
+-- The text profile-bonus RPC used to delegate to a UUID overload. That
+-- overload was intentionally removed to keep PostgREST RPC resolution
+-- unambiguous, leaving social sign-up inserts to fail whenever the new
+-- profile is complete. Keep the canonical text RPC self-contained.
+
+create or replace function public.airs_award_profile_completion_bonus(
+  p_user_id text,
+  p_bonus_amount numeric default 10,
+  p_source_ref text default 'profile-completion-bonus',
+  p_metadata jsonb default '{}'::jsonb
+)
+returns table (
+  awarded boolean,
+  status text,
+  ledger_entry_id uuid,
+  airs_balance numeric,
+  airs_lifetime_earned numeric,
+  profile_bonus_awarded_at timestamptz,
+  profile_completed_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user public.users;
+  v_entry public.airs_ledger_entries;
+begin
+  select * into v_user
+  from public.users
+  where id::text = p_user_id
+  for update;
+
+  if not found then
+    raise exception 'AIRS user % not found', p_user_id using errcode = 'P0002';
+  end if;
+
+  if not public.airs_is_profile_complete(v_user) then
+    return query
+      select false, 'profile_incomplete', null::uuid,
+             v_user.airs_balance, v_user.airs_lifetime_earned,
+             v_user.airs_profile_bonus_awarded_at, v_user.airs_profile_completed_at;
+    return;
+  end if;
+
+  if v_user.airs_profile_completed_at is null then
+    update public.users
+    set airs_profile_completed_at = timezone('utc', now())
+    where id::text = p_user_id
+      and airs_profile_completed_at is null;
+  end if;
+
+  insert into public.airs_lifecycle_events (user_id, event_type, metadata)
+  values (
+    p_user_id::uuid,
+    'profile_completed',
+    jsonb_build_object('source', 'profile_bonus', 'bonusAmount', p_bonus_amount, 'sourceRef', p_source_ref)
+      || coalesce(p_metadata, '{}'::jsonb)
+  )
+  on conflict (user_id, event_type) do nothing;
+
+  if v_user.airs_profile_bonus_awarded_at is not null then
+    return query
+      select false, 'already_awarded',
+        (select id from public.airs_ledger_entries
+         where user_id = p_user_id::uuid
+           and idempotency_key = p_source_ref
+         order by recorded_at desc limit 1),
+        v_user.airs_balance, v_user.airs_lifetime_earned,
+        v_user.airs_profile_bonus_awarded_at,
+        coalesce(v_user.airs_profile_completed_at, timezone('utc', now));
+    return;
+  end if;
+
+  v_entry := public.airs_record_ledger_entry(
+    p_user_id::uuid,
+    'profile_completion_bonus',
+    p_bonus_amount,
+    p_source_ref,
+    p_source_ref,
+    'USD',
+    null,
+    0,
+    'Profile completion bonus',
+    p_metadata
+  );
+
+  update public.users
+  set airs_profile_bonus_awarded_at = timezone('utc', now())
+  where id::text = p_user_id
+    and airs_profile_bonus_awarded_at is null;
+
+  insert into public.airs_lifecycle_events (user_id, event_type, ledger_entry_id, source_kind, source_ref, metadata)
+  values (
+    p_user_id::uuid,
+    'profile_bonus_awarded',
+    v_entry.id,
+    v_entry.source_kind,
+    v_entry.source_ref,
+    jsonb_build_object('bonusAmount', p_bonus_amount, 'sourceRef', p_source_ref)
+      || coalesce(p_metadata, '{}'::jsonb)
+  )
+  on conflict (user_id, event_type) do nothing;
+
+  return query
+    select true, 'awarded', v_entry.id, u.airs_balance, u.airs_lifetime_earned,
+           u.airs_profile_bonus_awarded_at, u.airs_profile_completed_at
+    from public.users u
+    where u.id::text = p_user_id;
+end;
+$$;
+
+create or replace function public.airs_handle_user_profile_completion_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if public.airs_is_profile_complete(new) then
+    if TG_OP = 'INSERT' then
+      if new.airs_profile_bonus_awarded_at is null then
+        perform public.airs_award_profile_completion_bonus(new.id::text);
+      end if;
+    elsif old.airs_profile_bonus_awarded_at is null and new.airs_profile_bonus_awarded_at is null then
+      perform public.airs_award_profile_completion_bonus(new.id::text);
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+grant execute on function public.airs_award_profile_completion_bonus(text, numeric, text, jsonb) to anon, authenticated;


### PR DESCRIPTION
## 📝 Description

Repairs the AIRS profile-bonus database trigger that blocked first-time social sign-ins, and routes dashboard email signup through Better Auth so verification messages use the managed Tlao SMTP secret.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style change (formatting, local variables)
- [ ] ♻️ Code refactoring (neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security improvement

## 🎯 Purpose

Restore Google account provisioning and remove the production email confirmation 502 without depending on the rejected Supabase management token.

## 🧪 Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested this change locally and it works as expected
- [x] All existing tests pass with my changes
- [ ] I have run the full test suite and coverage is maintained

## 📋 Checklist

- [x] My code follows the project's coding standards and style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## 🔗 Related Issues

Closes #N/A
Related to #N/A

## 📸 Screenshots (if applicable)

N/A

## 📝 Additional Notes

The production migration and runtime selector were applied as an incident mitigation; this PR makes both durable for subsequent deployments.

## 🔒 Security Considerations

- [x] I have considered the security implications of my changes
- [x] I have validated all user inputs
- [x] I have not introduced any new security vulnerabilities
- [x] I have followed the security best practices outlined in SECURITY.md

## 📊 Performance Impact

- [x] I have tested the performance impact of my changes
- [x] My changes do not negatively impact application performance
- [x] I have optimized any potentially slow operations

## 🚀 Deployment

- [x] I have tested this change in a staging environment
- [x] I have considered the deployment implications
- [x] I have updated any necessary deployment scripts or configurations

---

**By submitting this pull request, I confirm that:**

- I have read and understood the contributing guidelines
- I have read and understood the code of conduct
- My changes are licensed under the MIT license
- I have the right to submit these changes under the MIT license