### PR TITLE
fix: treat backend API Google OAuth as optional like Discord

### DIFF
--- a/packages/infra/scripts/resolve-secrets-manager-env.sh
+++ b/packages/infra/scripts/resolve-secrets-manager-env.sh
@@ -89,24 +89,31 @@ else
   backend_discord_client_id=${INFRA_BACKEND_API_DISCORD_AUTH_CLIENT_ID:-${DISCORD_AUTH_CLIENT_ID:-${DISCORD_CLIENT_ID:-}}}
   backend_discord_client_secret=${INFRA_BACKEND_API_DISCORD_AUTH_CLIENT_SECRET:-${DISCORD_AUTH_CLIENT_SECRET:-${DISCORD_CLIENT_SECRET:-}}}
 
-  # Discord is optional. If it is configured directly, require its complete
-  # credential pair before bypassing hydration; a half-configured provider must
-  # still be resolved from the integration secret (or fail clearly below).
+  # Google and Discord are both optional. If configured directly, require a
+  # complete credential pair before bypassing hydration; a half-configured
+  # provider must still be resolved from the integration secret (or fail
+  # clearly below).
   backend_google_credentials_complete=false
   backend_discord_credentials_complete=false
   backend_discord_not_configured=false
+  backend_google_not_configured=false
   [ -n "$backend_google_client_id" ] && [ -n "$backend_google_client_secret" ] && backend_google_credentials_complete=true
   [ -n "$backend_discord_client_id" ] && [ -n "$backend_discord_client_secret" ] && backend_discord_credentials_complete=true
   [ -z "$backend_discord_client_id" ] && [ -z "$backend_discord_client_secret" ] && backend_discord_not_configured=true
+  [ -z "$backend_google_client_id" ] && [ -z "$backend_google_client_secret" ] && backend_google_not_configured=true
 
   if [ "${INFRA_IDENTITY_ENABLED:-false}" != "true" ] && \
-    [ "$backend_google_credentials_complete" = "true" ] && \
+    { [ "$backend_google_credentials_complete" = "true" ] || [ "$backend_google_not_configured" = "true" ]; } && \
     { [ "$backend_discord_credentials_complete" = "true" ] || [ "$backend_discord_not_configured" = "true" ]; }; then
   # Better Auth owns backend social login. Once the Authentik stack is retired,
   # dashboard deployments must be able to use their independently configured
   # OAuth credentials without resolving the retired identity secret. An absent
-  # Discord pair intentionally leaves that optional provider disabled.
-    echo "Skipped retired identity secret resolution for backend stage '${STACK}'; configured backend OAuth credentials are complete." >&2
+  # Google or Discord pair intentionally leaves that optional provider disabled.
+    if [ "$backend_google_credentials_complete" = "true" ] || [ "$backend_discord_credentials_complete" = "true" ]; then
+      echo "Skipped retired identity secret resolution for backend stage '${STACK}'; configured backend OAuth credentials are complete." >&2
+    else
+      echo "Skipped retired identity secret resolution for backend stage '${STACK}'; Google and Discord OAuth are both unconfigured (optional)." >&2
+    fi
     return 0 2>/dev/null || exit 0
   fi
 

--- a/packages/infra/test/resolve-secrets-manager-env.test.ts
+++ b/packages/infra/test/resolve-secrets-manager-env.test.ts
@@ -20,6 +20,8 @@ void test('resolve-secrets-manager-env hydrates the stage-mapped identity integr
   assert.match(source, /configured backend OAuth credentials are complete/);
   assert.match(source, /backend_discord_credentials_complete/);
   assert.match(source, /backend_discord_not_configured/);
+  assert.match(source, /backend_google_not_configured/);
+  assert.match(source, /Google and Discord OAuth are both unconfigured \(optional\)/);
   assert.match(source, /googleClientId/);
   assert.match(source, /googleClientSecret/);
   assert.match(source, /discordClientId/);


### PR DESCRIPTION
## Summary
- alternun-dash-prod-pipeline was failing in PRE_BUILD because the legacy Authentik `alternun-infra/identity/integration-config/identity-prod` secret was deleted when the identity stack was retired, but `resolve-secrets-manager-env.sh` still hard-required Google OAuth credentials for backend API builds.
- Google auth is now bypassed the same way Discord already is, when neither is configured directly via env vars.

## Test plan
- [x] `node --test packages/infra/test/resolve-secrets-manager-env.test.ts` passes
- [x] Runtime simulation of the exact failing build conditions (`STACK=dashboard-prod INFRA_IDENTITY_ENABLED=false INFRA_ENABLE_BACKEND_API=true`, empty Google/Discord vars) now exits 0 instead of erroring
- [x] Verified no regression: "credentials complete" bypass path and `INFRA_IDENTITY_ENABLED=true` path behave unchanged
- [x] alternun-dash-dev-pipeline retriggered against this commit on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)