### PR TITLE
chore: release v1.1.46

### DIFF
--- a/packages/infra/scripts/resolve-ssm-env.sh
+++ b/packages/infra/scripts/resolve-ssm-env.sh
@@ -386,6 +386,10 @@ main() {
         expo-public-auth-exchange-url-prod
         expo-public-authentik-social-login-mode-prod
         database-url-prod
+        google-auth-client-id
+        google-auth-client-secret
+        discord-auth-client-id
+        discord-auth-client-secret
       )
       ;;
     *)
@@ -439,6 +443,10 @@ main() {
       export_env_from_ssm "EXPO_PUBLIC_AUTH_EXCHANGE_URL" "expo-public-auth-exchange-url-prod" "https://api.alternun.co/auth/exchange"
       export_env_from_ssm "EXPO_PUBLIC_AUTHENTIK_SOCIAL_LOGIN_MODE" "expo-public-authentik-social-login-mode-prod" "authentik"
       export_env_from_ssm "DATABASE_URL" "database-url-prod"
+      export_env_from_ssm "GOOGLE_AUTH_CLIENT_ID" "google-auth-client-id"
+      export_env_from_ssm "GOOGLE_AUTH_CLIENT_SECRET" "google-auth-client-secret"
+      export_env_from_ssm "DISCORD_AUTH_CLIENT_ID" "discord-auth-client-id"
+      export_env_from_ssm "DISCORD_AUTH_CLIENT_SECRET" "discord-auth-client-secret"
       ;;
     *)
       export_env_from_ssm "EXPO_PUBLIC_BETTER_AUTH_URL" "expo-public-better-auth-url" ""

--- a/packages/infra/test/resolve-ssm-env-cache.test.ts
+++ b/packages/infra/test/resolve-ssm-env-cache.test.ts
@@ -61,3 +61,18 @@ void test('resolve-ssm-env refreshes cached auth env when the public Supabase ke
     /export_env_from_ssm "EXPO_PUBLIC_SUPABASE_KEY" "expo-public-supabase-key" "" "\$\{SSM_SHARED_STAGE\}"/
   );
 });
+
+void test('resolve-ssm-env resolves Google and Discord OAuth credentials for production stages', () => {
+  const source = fs.readFileSync(helperPath, 'utf8');
+
+  assert.match(source, /export_env_from_ssm "GOOGLE_AUTH_CLIENT_ID" "google-auth-client-id"/);
+  assert.match(
+    source,
+    /export_env_from_ssm "GOOGLE_AUTH_CLIENT_SECRET" "google-auth-client-secret"/
+  );
+  assert.match(source, /export_env_from_ssm "DISCORD_AUTH_CLIENT_ID" "discord-auth-client-id"/);
+  assert.match(
+    source,
+    /export_env_from_ssm "DISCORD_AUTH_CLIENT_SECRET" "discord-auth-client-secret"/
+  );
+});


### PR DESCRIPTION
## Summary
- fix(infra): resolve Google/Discord OAuth credentials from SSM for production stages (`resolve-ssm-env.sh`'s prod case block never fetched `google-auth-client-id`/`-secret` or `discord-auth-client-id`/`-secret` from SSM, unlike the dev block — this is why production Google sign-in returns 404 "Provider not found")

## Test plan
- [x] `node --test packages/infra/test/resolve-ssm-env-cache.test.ts` passes
- [x] Mobile coverage suite passes (pre-push hook, 70%+ threshold)
- [ ] After merge: provision/confirm `/alternun-infra/production/google-auth-client-id` and `-secret` in SSM (already done), redeploy `alternun-dash-prod-pipeline`, verify Google sign-in on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)